### PR TITLE
Adds hub url handling

### DIFF
--- a/src/Hub/Services/HubIntegrationService.php
+++ b/src/Hub/Services/HubIntegrationService.php
@@ -49,8 +49,9 @@ final class HubIntegrationService
 
         $installToken = $tokenRepo->findByPagarmeId(new HubInstallToken($installToken));
 
-        if (is_a($installToken, InstallToken::class) 
-            && !$installToken->isExpired() 
+        if (
+            is_a($installToken, InstallToken::class)
+            && !$installToken->isExpired()
             && !$installToken->isUsed()
         ) {
             $body = [
@@ -65,7 +66,7 @@ final class HubIntegrationService
                 $body['webhook_url'] = $webhookUrl;
             }
 
-            $url = 'https://hubapi.mundipagg.com/auth/apps/access-tokens';
+            $url = 'https://stg-hubapi.mundipagg.com/auth/apps/access-tokens';
             $headers = [
                 'PublicAppKey' => MPSetup::getHubAppPublicAppKey(),
                 'Content-Type' => 'application/json'

--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -4,6 +4,7 @@ namespace Pagarme\Core\Kernel\Abstractions;
 
 use Pagarme\Core\Kernel\Aggregates\Configuration;
 use Pagarme\Core\Kernel\Repositories\ConfigurationRepository;
+use MundiAPILib\Configuration as MundiAPIConfiguration;
 use ReflectionClass;
 
 abstract class AbstractModuleCoreSetup
@@ -72,6 +73,15 @@ abstract class AbstractModuleCoreSetup
             static::$platformRoot = $platformRoot;
 
             static::updateModuleConfiguration();
+
+            static::$instance->setApiBaseUrl();
+        }
+    }
+
+    protected static function setApiBaseUrl()
+    {
+        if (static::$moduleConfig->isHubEnabled()) {
+            MundiAPIConfiguration::$BASEURI = 'https://stg-hubapi.mundipagg.com/core/v1';
         }
     }
 
@@ -98,7 +108,7 @@ abstract class AbstractModuleCoreSetup
             static::$moduleConfig->setStoreId(static::getCurrentStoreId());
         }
 
-        if(
+        if (
             static::$moduleConfig->getStoreId() != static::getDefaultStoreId() &&
             $savedConfig === null
         ) {
@@ -241,7 +251,7 @@ abstract class AbstractModuleCoreSetup
 
     public static function setModuleConcreteDir($concreteModuleDir)
     {
-        if(!isset(self::$moduleConcreteDir)) {
+        if (!isset(self::$moduleConcreteDir)) {
             self::$moduleConcreteDir = $concreteModuleDir;
         }
     }
@@ -288,4 +298,3 @@ abstract class AbstractModuleCoreSetup
      */
     abstract protected function getPlatformStoreTimezone();
 }
-


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-125
| **What?**         | Changes the base api url to hub's one if hub is enabled.
| **Why?**          | To allow hub integrations automatically when using core.

**Important Notes:**
- We're still using **staging hub url**. 
<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)
Add additional informations like screenshots, issue link, etc

#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
