### PR TITLE
Uses additional information in pix payments

### DIFF
--- a/src/Kernel/Factories/Configurations/PixConfigFactory.php
+++ b/src/Kernel/Factories/Configurations/PixConfigFactory.php
@@ -27,6 +27,17 @@ class PixConfigFactory implements FactoryCreateFromDbDataInterface
             $pixConfig->setExpirationQrCode($data->expirationQrCode);
         }
 
+        if (!empty($data->additionalInformation)) {
+            $additionalInformationArray = json_decode(
+                json_encode($data->additionalInformation),
+                true
+            );
+
+            $pixConfig->setAdditionalInformation(
+                $additionalInformationArray
+            );
+        }
+
         if (!empty($data->bankType)) {
             $pixConfig->setBankType(
                 $data->bankType

--- a/src/Kernel/ValueObjects/Configuration/PixConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/PixConfig.php
@@ -23,6 +23,11 @@ class PixConfig extends AbstractValueObject
     private $bankType;
 
     /**
+     * @var array
+     */
+    private $additionalInformation;
+
+    /**
      * @return bool
      */
     public function isEnabled()
@@ -95,6 +100,24 @@ class PixConfig extends AbstractValueObject
     }
 
     /**
+     * @return array
+     */
+    public function getAdditionalInformation()
+    {
+        return $this->additionalInformation;
+    }
+
+    /**
+     * @param array $additionalInformation
+     * @return PixConfig
+     */
+    public function setAdditionalInformation($additionalInformation)
+    {
+        $this->additionalInformation = $additionalInformation;
+        return $this;
+    }
+
+    /**
      * To check the structural equality of value objects,
      * this method should be implemented in this class children.
      *
@@ -106,7 +129,8 @@ class PixConfig extends AbstractValueObject
         return
             $this->enabled === $object->isEnabled() &&
             $this->bankType === $object->getBankType() &&
-            $this->expirationQrCode === $object->getExpirationQrCode();
+            $this->expirationQrCode === $object->getExpirationQrCode() &&
+            $this->additionalInformation === $object->getAdditionalInformation();
     }
 
     /**
@@ -122,7 +146,8 @@ class PixConfig extends AbstractValueObject
             "enabled" => $this->enabled,
             "title" => $this->getTitle(),
             "bankType" => $this->getBankType(),
-            "expirationQrCode" => $this->getExpirationQrCode()
+            "expirationQrCode" => $this->getExpirationQrCode(),
+            "additionalInformation" => $this->getAdditionalInformation()
         ];
     }
 }

--- a/src/Payment/Factories/PaymentFactory.php
+++ b/src/Payment/Factories/PaymentFactory.php
@@ -117,8 +117,7 @@ final class PaymentFactory
         $cardData,
         $cardDataIndex,
         $config
-    )
-    {
+    ) {
         $payment = $this->createBaseCardPayment($cardData, $cardDataIndex);
 
         if ($payment === null) {
@@ -190,8 +189,7 @@ final class PaymentFactory
     private function getAmountWithInterestForCreditCard(
         AbstractCreditCardPayment $payment,
         $config
-    )
-    {
+    ) {
         $installmentService = new InstallmentService();
 
         $validInstallments = $installmentService->getInstallmentsFor(
@@ -266,6 +264,13 @@ final class PaymentFactory
                 $payment->setCustomer($customer);
             }
 
+            $additionalInformation =
+                $this->moduleConfig->getPixConfig()->getAdditionalInformation();
+
+            if (!empty($additionalInformation)) {
+                $payment->setAdditionalInformation($additionalInformation);
+            }
+
             $payment->setAmount($value->amount);
 
             $payments[] = $payment;
@@ -290,10 +295,8 @@ final class PaymentFactory
                 $payment->setSaveOnSuccess($data->saveOnSuccess);
             }
             return $payment;
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         } catch (\Throwable $e) {
-
         }
 
         try {
@@ -309,10 +312,8 @@ final class PaymentFactory
             $payment->setOwner($owner);
 
             return $payment;
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         } catch (\Throwable $e) {
-
         }
 
         return null;

--- a/tests/Kernel/Factories/Configurations/PixConfigFactoryTest.php
+++ b/tests/Kernel/Factories/Configurations/PixConfigFactoryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Pagarme\Core\Test\Kernel\Aggregates\Factories\Configurations;
+
+
+use Pagarme\Core\Kernel\Factories\Configurations\PixConfigFactory;
+use PHPUnit\Framework\TestCase;
+use Mockery;
+use Carbon\Carbon;
+
+class PixConfigFactoryTest extends TestCase
+{
+    /**
+     * @var object
+     */
+    private $dataWithAdditionalInformation;
+    /**
+     * @var PixConfigFactory
+     */
+    private $pixConfigFactory;
+
+    public function setUp()
+    {
+        $this->dataWithAdditionalInformation = (object) array(
+            'enabled' => true,
+            'expirationQrCode' => 300,
+            'bankType' => 'Pagar.me',
+            'additionalInformation' => array(
+                array(
+                    'name' => 'information name',
+                    'value' => 'information value'
+                )
+            )
+        );
+
+        $this->pixConfigFactory = new PixConfigFactory();
+    }
+
+    public function testCreatePixConfigurationWithAdditionalConfiguration()
+    {
+        $pixConfig = $this->pixConfigFactory
+            ->createFromDbData($this->dataWithAdditionalInformation);
+
+        $this->assertEquals(
+            $this->dataWithAdditionalInformation->additionalInformation,
+            $pixConfig->getAdditionalInformation()
+        );
+
+        $serializedPixConfig = $pixConfig->jsonSerialize();
+
+        $this->assertEquals(
+            (array) $this->dataWithAdditionalInformation->additionalInformation,
+            $serializedPixConfig["additionalInformation"]
+        );
+    }
+
+    public function testCreatePixConfigurationWithoutAdditionalConfiguration()
+    {
+        $dataWithoutAdditionalInformation =
+            clone $this->dataWithAdditionalInformation;
+
+        unset($dataWithoutAdditionalInformation->additionalInformation);
+
+        $pixConfig = $this->pixConfigFactory
+            ->createFromDbData($dataWithoutAdditionalInformation);
+
+        $this->assertEquals(
+            null,
+            $pixConfig->getAdditionalInformation()
+        );
+
+        $serializedPixConfig = $pixConfig->jsonSerialize();
+
+        $this->assertEquals(
+            null,
+            $serializedPixConfig["additionalInformation"]
+        );
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-162
| **What?**         | Makes core uses pix additional information if it is set.
| **Why?**          | To show extra information when scanning pix qrcode.
| **How?**          | adding additional information in `PixConfig.php` and using additionalInformation, if is set in module's config.