### PR TITLE
Fixes error to create subscriptions

### DIFF
--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -564,21 +564,12 @@ class Subscription extends AbstractEntity
             return;
         }
 
-        if(!empty($subscriptionRequest->cardId)){
-            return;
-        }
-
-        if(!empty($subscriptionRequest->cardToken)){
-            return;
-        }
-
         $card = new CreateCardRequest();
         if ($this->getCustomer()->getAddress() != null) {
             $card->billingAddress = $this->getCustomer()->getAddress()->convertToSDKRequest();
         }
 
         $subscriptionRequest->card = $card;
-
     }
 
     public function getStatusValue()

--- a/tests/Recurrence/Aggregates/SubscriptionTest.php
+++ b/tests/Recurrence/Aggregates/SubscriptionTest.php
@@ -190,10 +190,12 @@ class SubscriptionTest extends TestCase
         $this->assertCount(2, $this->subscription->getCharges());
     }
 
-    public function testShouldReturnACardObjectWithBillingAddressOnCreateSubscriptionRequest()
+    public function testShouldReturnACreateSubscriptionRequestObjectWithCardBillingAddress()
     {
         $this->subscription->setCustomer(new Customer());
         $this->subscription->setItems([new SubProduct]);
+        $this->subscription->getCustomer()->setAddress(new Address());
+        $this->subscription->setCardToken("cardToken");
 
         $shipping = new Shipping;
         $shipping->setRecipientPhone(new Phone("021999999999"));
@@ -202,11 +204,37 @@ class SubscriptionTest extends TestCase
         $this->subscription->setShipping($shipping);
 
         $card = new CreateCardRequest();
-        $card->billingAddress = new CreateAddressRequest();
+        $card->billingAddress = $this->subscription->getCustomer()
+            ->getAddress()->convertToSDKRequest();
         $this->subscription->card = $card;
 
         $sdkObject = $this->subscription->convertToSdkRequest();
-        $this->assertInstanceOf(CreateCardRequest::class, $this->subscription->card);
-        $this->assertInstanceOf(CreateAddressRequest::class, $this->subscription->card->billingAddress);
+
+        $this->assertInstanceOf(CreateSubscriptionRequest::class, $sdkObject);
+        $this->assertNotNull($sdkObject->card->billingAddress);
+    }
+
+    public function testShouldReturnACreateSubscriptionRequestObjectWithSavedCardBillingAddress()
+    {
+        $this->subscription->setCustomer(new Customer());
+        $this->subscription->setItems([new SubProduct]);
+        $this->subscription->getCustomer()->setAddress(new Address());
+        $this->subscription->setCardId("cardId");
+
+        $shipping = new Shipping;
+        $shipping->setRecipientPhone(new Phone("021999999999"));
+        $shipping->setAddress(new Address());
+
+        $this->subscription->setShipping($shipping);
+
+        $card = new CreateCardRequest();
+        $card->billingAddress = $this->subscription->getCustomer()
+            ->getAddress()->convertToSDKRequest();
+        $this->subscription->card = $card;
+
+        $sdkObject = $this->subscription->convertToSdkRequest();
+
+        $this->assertInstanceOf(CreateSubscriptionRequest::class, $sdkObject);
+        $this->assertNotNull($sdkObject->card->billingAddress);
     }
 }

--- a/tests/Recurrence/Aggregates/SubscriptionTest.php
+++ b/tests/Recurrence/Aggregates/SubscriptionTest.php
@@ -3,6 +3,8 @@
 namespace Pagarme\Core\Test\Recurrence\Aggregates;
 
 use Mockery;
+use MundiAPILib\Models\CreateAddressRequest;
+use MundiAPILib\Models\CreateCardRequest;
 use MundiAPILib\Models\CreateSubscriptionRequest;
 use Pagarme\Core\Kernel\Interfaces\PlatformOrderInterface;
 use Pagarme\Core\Kernel\ValueObjects\Id\ChargeId;
@@ -186,5 +188,25 @@ class SubscriptionTest extends TestCase
 
         $this->assertContainsOnlyInstancesOf(Charge::class, $this->subscription->getCharges());
         $this->assertCount(2, $this->subscription->getCharges());
+    }
+
+    public function testShouldReturnACardObjectWithBillingAddressOnCreateSubscriptionRequest()
+    {
+        $this->subscription->setCustomer(new Customer());
+        $this->subscription->setItems([new SubProduct]);
+
+        $shipping = new Shipping;
+        $shipping->setRecipientPhone(new Phone("021999999999"));
+        $shipping->setAddress(new Address());
+
+        $this->subscription->setShipping($shipping);
+
+        $card = new CreateCardRequest();
+        $card->billingAddress = new CreateAddressRequest();
+        $this->subscription->card = $card;
+
+        $sdkObject = $this->subscription->convertToSdkRequest();
+        $this->assertInstanceOf(CreateCardRequest::class, $this->subscription->card);
+        $this->assertInstanceOf(CreateAddressRequest::class, $this->subscription->card->billingAddress);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-212
| **What?**         | Fixes error to create subscriptions for new buyers.
| **Why?**          | Our module is not sending the billing_address parameter inside the card object.
| **How?**          | Removing code snippet to send the card object.

