### PR TITLE
Fixes logs when hub token not found in database

### DIFF
--- a/src/Hub/Commands/AbstractCommand.php
+++ b/src/Hub/Commands/AbstractCommand.php
@@ -44,8 +44,11 @@ abstract class AbstractCommand implements CommandInterface
      * @var CommandType
      */
     protected $type;
-
-    private $logService;
+    /**
+     *
+     * @var LogService
+     */
+    protected $logService;
 
     public function __construct()
     {

--- a/src/Hub/Services/HubIntegrationService.php
+++ b/src/Hub/Services/HubIntegrationService.php
@@ -55,7 +55,18 @@ final class HubIntegrationService
     ) {
         $tokenRepo = new InstallTokenRepository();
 
+        $rawToken = $installToken;
+
         $installToken = $tokenRepo->findByPagarmeId(new HubInstallToken($installToken));
+
+        if (empty($installToken)) {
+            $message = "installToken not found in database. Raw Token: $rawToken";
+
+            $exception = new \Exception($message);
+
+            $this->logService->exception($exception);
+            throw $exception;
+        }
 
         $isValidToken = is_a($installToken, InstallToken::class)
             && !$installToken->isExpired()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-228
| **What?**         | Adds logs when token not found in database.
| **Why?**          | To help us to identify the issue if we see this scenario in a case.
| **How?**          | Adding a log message when the instalToken is empty.

**Notes**
- Also fix a visibility issue in logService parameter of AbstractCommand.