### PR TITLE
Sanitize customer document

### DIFF
--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -122,7 +122,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setDocument($document)
     {
-        $this->document = substr($document, 0, 16);
+        $this->document = $this->formatDocument($document);
 
         if (empty($this->document)) {
 
@@ -255,5 +255,15 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
 
             throw new \Exception($message, 400);
         }
+    }
+
+    private function formatDocument($document)
+    {
+        $document = preg_replace(
+            '/[^0-9]/is', '',
+            substr($document, 0, 16)
+        );
+
+        return $document;
     }
 }

--- a/tests/Payment/Aggregates/CustomerTests.php
+++ b/tests/Payment/Aggregates/CustomerTests.php
@@ -55,4 +55,17 @@ class CustomerTests extends TestCase
             $emailMaxLength, strlen($this->customer->getEmail())
         );
     }
+
+    public function testDocumentSanitize()
+    {
+        $document = "12345678910";
+        $customerDocument = "123.456.789-10";
+
+        $this->customer->setCode(5);
+        $this->customer->setDocument($customerDocument);
+
+        $this->assertEquals(
+            $document, $this->customer->getDocument()
+        );
+    }
 }

--- a/tests/Payment/Aggregates/CustomerTests.php
+++ b/tests/Payment/Aggregates/CustomerTests.php
@@ -58,14 +58,14 @@ class CustomerTests extends TestCase
 
     public function testDocumentSanitize()
     {
-        $document = "12345678910";
+        $expectedDocument = "12345678910";
         $customerDocument = "123.456.789-10";
 
         $this->customer->setCode(5);
         $this->customer->setDocument($customerDocument);
 
         $this->assertEquals(
-            $document, $this->customer->getDocument()
+            $expectedDocument, $this->customer->getDocument()
         );
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-185
| **What?**         | Sanitize customer document to fix invalid request
| **Why?**          | Because the invalid request caused an error when editing a customer or update the credit to the customer's account