### PR TITLE
Removes old php version from Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,87 +13,62 @@ variables:
 - group: Ecommerce_module_core_STG
 - name: phpCurrentVersion
   value: 7.2
-- name: phpOldVersion
-  value: 5.6
 
 stages:
 - stage: Build_PHP_Seven
-  jobs:    
+  jobs:
   - job: Build
-    steps:          
-    
-    - script: |     
+    steps:
+
+    - script: |
         sudo update-alternatives --set php /usr/bin/php$(phpCurrentVersion)
         sudo update-alternatives --set phar /usr/bin/phar$(phpCurrentVersion)
         sudo update-alternatives --set phpdbg /usr/bin/phpdbg$(phpCurrentVersion)
         sudo update-alternatives --set php-cgi /usr/bin/php-cgi$(phpCurrentVersion)
         sudo update-alternatives --set phar.phar /usr/bin/phar.phar$(phpCurrentVersion)
         sudo apt-get install php7.2-xdebug
-        php -version        
-      displayName: Build PHP Version $(phpCurrentVersion)  
+        php -version
+      displayName: Build PHP Version $(phpCurrentVersion)
 
-    - script: |     
+    - script: |
         sudo apt-get install php7.2-xdebug
-        php -version             
+        php -version
       displayName: Install PHP extensions
-    
-    - script: |             
-        sudo composer self-update --1
-        composer        
-      displayName: Update Composer     
 
-    - script: |             
-        composer install --no-interaction --prefer-dist 
+    - script: |
+        sudo composer self-update --1
+        composer
+      displayName: Update Composer
+
+    - script: |
+        composer install --no-interaction --prefer-dist
       displayName: Install dependecy
 
-    - script: |                                     
-        export XDEBUG_MODE=coverage        
+    - script: |
+        export XDEBUG_MODE=coverage
         vendor/bin/phpunit --coverage-clover $(System.DefaultWorkingDirectory)/artifact/clover.xml
-      displayName: UnitTests             
+      displayName: UnitTests
     - task: PublishPipelineArtifact@1
       displayName: Download Artifact
       inputs:
         path: '$(System.DefaultWorkingDirectory)/artifact'
         artifact: artifact
   - job: SonarCloud
-    dependsOn: 
+    dependsOn:
     - Build
     condition: succeeded()
-    steps: 
+    steps:
     - task: DownloadPipelineArtifact@2
       inputs:
         artifact: artifact
-        
+
     - script: |
         export SONAR_SCANNER_VERSION=4.4.0.2170
         export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux
         curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
         unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
         export PATH=$SONAR_SCANNER_HOME/bin:$PATH
-        export SONAR_SCANNER_OPTS="-server"    
+        export SONAR_SCANNER_OPTS="-server"
         export SONAR_TOKEN="$(sonarcloud_token)"
         sonar-scanner   -Dsonar.organization=$(organization)   -Dsonar.projectKey=$(projectKey)   -Dsonar.sources=.   -Dsonar.host.url=https://sonarcloud.io -Dsonar.php.coverage.reportPaths="$(Pipeline.Workspace)/clover.xml"
-      displayName: Send to SonarCloud          
-
-- stage: Build_PHP_Five
-  jobs:    
-  - job: Build
-    steps:          
-    
-    - script: |     
-        sudo update-alternatives --set php /usr/bin/php$(phpOldVersion)
-        sudo update-alternatives --set phar /usr/bin/phar$(phpOldVersion)
-        sudo update-alternatives --set phpdbg /usr/bin/phpdbg$(phpOldVersion)
-        sudo update-alternatives --set php-cgi /usr/bin/php-cgi$(phpOldVersion)
-        sudo update-alternatives --set phar.phar /usr/bin/phar.phar$(phpOldVersion)      
-        php -version        
-      displayName: Build PHP Version $(phpOldVersion)  
-
-    - script: |             
-        composer install --no-interaction --prefer-dist 
-      displayName: Install dependecy
-
-    - script: |                             
-        cd control-media-backend             
-        vendor/bin/phpunit
-      displayName: UnitTests      
+      displayName: Send to SonarCloud           


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Removes old php version from Azure CI
| **Why?**          | Because we don't support it anymore and this version is breaking the CI