### PR TITLE
Missing function's return type declaration

### DIFF
--- a/src/Kernel/Log/JsonPrettyFormatter.php
+++ b/src/Kernel/Log/JsonPrettyFormatter.php
@@ -7,12 +7,12 @@ use Pagarme\Core\Kernel\Factories\LogObjectFactory;
 
 class JsonPrettyFormatter extends JsonFormatter
 {
-    public function format(array $record)
+    public function format(array $record): string
     {
         $logObjectFactory = new LogObjectFactory();
         $logObject = $logObjectFactory->createFromArray($record['context']);
 
-        $msg  =
+        $msg =
             "[{$record['datetime']->format('Y-m-d h:i:s')}] " .
             "{$record['channel']}.{$record['level_name']}: " .
             "{$record['message']}" . PHP_EOL;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-484
| **What?**         | Pagar.me Core does not support Magento 2.4.4.
| **Why?**          | Allow Magento works in latest version.
| **How?**          | Monolog library dependency can be any version.

