### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the repository of Pagar.me's payment module core for all supported e-com
 -   [Pagar.me Magento payment module for Magento 2.3+](https://github.com/pagarme/magento2).
 
 ## Dependencies
-*   ``PHP`` Version 7.1+
+*   ``PHP`` Version 7.1 - 7.4
 
 ## Install
 Require by composer

--- a/src/Kernel/Log/JsonPrettyFormatter.php
+++ b/src/Kernel/Log/JsonPrettyFormatter.php
@@ -7,12 +7,12 @@ use Pagarme\Core\Kernel\Factories\LogObjectFactory;
 
 class JsonPrettyFormatter extends JsonFormatter
 {
-    public function format(array $record)
+    public function format(array $record): string
     {
         $logObjectFactory = new LogObjectFactory();
         $logObject = $logObjectFactory->createFromArray($record['context']);
 
-        $msg  =
+        $msg =
             "[{$record['datetime']->format('Y-m-d h:i:s')}] " .
             "{$record['channel']}.{$record['level_name']}: " .
             "{$record['message']}" . PHP_EOL;


### PR DESCRIPTION
Questions | Answers
-- | --
Issue | https://mundipagg.atlassian.net/browse/PAOP-484
What? | Pagar.me Core does not support Magento 2.4.4.
Why? | Allow Magento works in latest version.
How? | Monolog library dependency can be any version.
