### PR TITLE
:bug: Fix jsonSerialize returning type

### DIFF
--- a/src/Hub/Aggregates/InstallToken.php
+++ b/src/Hub/Aggregates/InstallToken.php
@@ -136,7 +136,7 @@ final class InstallToken extends AbstractEntity
      *
      * @return array|mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Hub/Commands/CommandType.php
+++ b/src/Hub/Commands/CommandType.php
@@ -72,7 +72,7 @@ final class CommandType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->value;
     }

--- a/src/Kernel/Aggregates/Charge.php
+++ b/src/Kernel/Aggregates/Charge.php
@@ -456,7 +456,7 @@ final class Charge extends AbstractEntity implements ChargeInterface
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -713,7 +713,7 @@ final class Configuration extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/Aggregates/LogObject.php
+++ b/src/Kernel/Aggregates/LogObject.php
@@ -96,7 +96,7 @@ final class LogObject extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $baseObject = new \stdClass();
 

--- a/src/Kernel/Aggregates/Order.php
+++ b/src/Kernel/Aggregates/Order.php
@@ -200,7 +200,7 @@ final class Order extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Aggregates/Transaction.php
+++ b/src/Kernel/Aggregates/Transaction.php
@@ -398,7 +398,7 @@ final class Transaction extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Exceptions/AbstractPagarmeCoreException.php
+++ b/src/Kernel/Exceptions/AbstractPagarmeCoreException.php
@@ -17,7 +17,7 @@ abstract class AbstractPagarmeCoreException
       * which is a value of any type other than a resource.
       * @since  5.4.0
       */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/AbstractValidString.php
+++ b/src/Kernel/ValueObjects/AbstractValidString.php
@@ -73,7 +73,7 @@ abstract class AbstractValidString extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->getValue();
     }

--- a/src/Kernel/ValueObjects/CardBrand.php
+++ b/src/Kernel/ValueObjects/CardBrand.php
@@ -179,7 +179,7 @@ final class CardBrand extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->getName();
     }

--- a/src/Kernel/ValueObjects/ChargeStatus.php
+++ b/src/Kernel/ValueObjects/ChargeStatus.php
@@ -106,7 +106,7 @@ final class ChargeStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->status;
     }

--- a/src/Kernel/ValueObjects/Configuration/AddressAttributes.php
+++ b/src/Kernel/ValueObjects/Configuration/AddressAttributes.php
@@ -89,7 +89,7 @@ final class AddressAttributes extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/CardConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/CardConfig.php
@@ -268,7 +268,7 @@ final class CardConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/DebitConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/DebitConfig.php
@@ -177,7 +177,7 @@ class DebitConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Configuration/PixConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/PixConfig.php
@@ -140,7 +140,7 @@ class PixConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Configuration/RecurrenceConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/RecurrenceConfig.php
@@ -178,7 +178,7 @@ class RecurrenceConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/VoucherConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/VoucherConfig.php
@@ -177,7 +177,7 @@ class VoucherConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Installment.php
+++ b/src/Kernel/ValueObjects/Installment.php
@@ -168,7 +168,7 @@ final class Installment extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass;
 

--- a/src/Kernel/ValueObjects/InvoiceState.php
+++ b/src/Kernel/ValueObjects/InvoiceState.php
@@ -75,7 +75,7 @@ final class InvoiceState extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->getState();
     }

--- a/src/Kernel/ValueObjects/OrderState.php
+++ b/src/Kernel/ValueObjects/OrderState.php
@@ -111,7 +111,7 @@ final class OrderState extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->getState();
     }

--- a/src/Kernel/ValueObjects/OrderStatus.php
+++ b/src/Kernel/ValueObjects/OrderStatus.php
@@ -98,7 +98,7 @@ final class OrderStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->getStatus();
     }

--- a/src/Kernel/ValueObjects/PaymentMethod.php
+++ b/src/Kernel/ValueObjects/PaymentMethod.php
@@ -92,7 +92,7 @@ final class PaymentMethod extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->paymentMethod;
     }

--- a/src/Kernel/ValueObjects/TransactionStatus.php
+++ b/src/Kernel/ValueObjects/TransactionStatus.php
@@ -184,7 +184,7 @@ final class TransactionStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->status;
     }

--- a/src/Kernel/ValueObjects/TransactionType.php
+++ b/src/Kernel/ValueObjects/TransactionType.php
@@ -92,7 +92,7 @@ final class TransactionType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->type;
     }

--- a/src/Kernel/ValueObjects/VersionInfo.php
+++ b/src/Kernel/ValueObjects/VersionInfo.php
@@ -109,7 +109,7 @@ final class VersionInfo extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Address.php
+++ b/src/Payment/Aggregates/Address.php
@@ -340,7 +340,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -177,7 +177,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Item.php
+++ b/src/Payment/Aggregates/Item.php
@@ -119,7 +119,7 @@ final class Item extends AbstractEntity implements ConvertibleToSDKRequestsInter
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Order.php
+++ b/src/Payment/Aggregates/Order.php
@@ -280,7 +280,7 @@ final class Order extends AbstractEntity implements ConvertibleToSDKRequestsInte
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Payments/AbstractCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractCreditCardPayment.php
@@ -180,9 +180,9 @@ abstract class AbstractCreditCardPayment extends AbstractPayment
         $this->brand = $brand;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        $obj =  parent::jsonSerialize();
+        $obj =  parent::jsonSerialize(): string;
 
         $obj->installments = $this->installments;
         $obj->brand = $this->brand;

--- a/src/Payment/Aggregates/Payments/AbstractPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractPayment.php
@@ -18,7 +18,7 @@ abstract class AbstractPayment
     use WithCustomerTrait;
     use WithOrderTrait;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Payments/BoletoPayment.php
+++ b/src/Payment/Aggregates/Payments/BoletoPayment.php
@@ -49,9 +49,9 @@ final class BoletoPayment extends AbstractPayment
         $this->instructions = $instructions;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        $obj = parent::jsonSerialize();
+        $obj = parent::jsonSerialize(): string;
 
         $obj->bank = $this->bank;
         $obj->instructions = $this->instructions;

--- a/src/Payment/Aggregates/Payments/NewCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/NewCreditCardPayment.php
@@ -49,9 +49,9 @@ class NewCreditCardPayment extends AbstractCreditCardPayment
         $this->saveOnSuccess = boolval($saveOnSuccess);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        $obj = parent::jsonSerialize();
+        $obj = parent::jsonSerialize(): string;
 
         $obj->cardToken = $this->identifier;
 

--- a/src/Payment/Aggregates/Payments/NewVoucherPayment.php
+++ b/src/Payment/Aggregates/Payments/NewVoucherPayment.php
@@ -52,9 +52,9 @@ final class NewVoucherPayment extends AbstractCreditCardPayment
         $this->saveOnSuccess = boolval($saveOnSuccess);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        $obj = parent::jsonSerialize();
+        $obj = parent::jsonSerialize(): string;
 
         $obj->cardToken = $this->identifier;
 

--- a/src/Payment/Aggregates/Payments/PixPayment.php
+++ b/src/Payment/Aggregates/Payments/PixPayment.php
@@ -72,9 +72,9 @@ final class PixPayment extends AbstractPayment
         $this->additionalInformation = $additionalInformation;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        $obj = parent::jsonSerialize();
+        $obj = parent::jsonSerialize(): string;
         $obj->expiresIn = $this->getExpiresIn();
         $obj->expiresAt = $this->getExpiresAt();
         $obj->additionalInformation = $this->getAdditionalInformation();

--- a/src/Payment/Aggregates/Payments/SavedCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedCreditCardPayment.php
@@ -30,9 +30,9 @@ final class SavedCreditCardPayment extends AbstractCreditCardPayment
         $this->owner = $owner;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        $obj = parent::jsonSerialize();
+        $obj = parent::jsonSerialize(): string;
 
         $obj->cardId = $this->identifier;
         $obj->owner = $this->owner;

--- a/src/Payment/Aggregates/Payments/SavedDebitCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedDebitCardPayment.php
@@ -30,9 +30,9 @@ final class SavedDebitCardPayment extends AbstractCreditCardPayment
         $this->owner = $owner;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        $obj = parent::jsonSerialize();
+        $obj = parent::jsonSerialize(): string;
 
         $obj->cardId = $this->identifier;
         $obj->owner = $this->owner;

--- a/src/Payment/Aggregates/Payments/SavedVoucherCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedVoucherCardPayment.php
@@ -42,9 +42,9 @@ final class SavedVoucherCardPayment extends AbstractCreditCardPayment
         return $this->cvv;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        $obj = parent::jsonSerialize();
+        $obj = parent::jsonSerialize(): string;
 
         $obj->cardId = $this->identifier;
         $obj->owner = $this->owner;

--- a/src/Payment/Aggregates/SavedCard.php
+++ b/src/Payment/Aggregates/SavedCard.php
@@ -132,7 +132,7 @@ final class SavedCard extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Shipping.php
+++ b/src/Payment/Aggregates/Shipping.php
@@ -92,7 +92,7 @@ final class Shipping extends AbstractEntity implements ConvertibleToSDKRequestsI
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/BoletoBank.php
+++ b/src/Payment/ValueObjects/BoletoBank.php
@@ -109,7 +109,7 @@ class BoletoBank extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
        $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/CustomerPhones.php
+++ b/src/Payment/ValueObjects/CustomerPhones.php
@@ -82,7 +82,7 @@ final class CustomerPhones extends AbstractValueObject implements ConvertibleToS
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/CustomerType.php
+++ b/src/Payment/ValueObjects/CustomerType.php
@@ -54,7 +54,7 @@ class CustomerType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->type;
     }

--- a/src/Payment/ValueObjects/Discounts.php
+++ b/src/Payment/ValueObjects/Discounts.php
@@ -93,7 +93,7 @@ class Discounts extends AbstractValueObject
     /**
      * @return array|mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return get_object_vars($this);
     }

--- a/src/Payment/ValueObjects/PaymentMethod.php
+++ b/src/Payment/ValueObjects/PaymentMethod.php
@@ -98,7 +98,7 @@ final class PaymentMethod extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->getMethod();
     }

--- a/src/Payment/ValueObjects/Phone.php
+++ b/src/Payment/ValueObjects/Phone.php
@@ -86,7 +86,7 @@ final class Phone extends AbstractValueObject implements ConvertibleToSDKRequest
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/PixBank.php
+++ b/src/Payment/ValueObjects/PixBank.php
@@ -109,7 +109,7 @@ class PixBank extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
        $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/Charge.php
+++ b/src/Recurrence/Aggregates/Charge.php
@@ -549,7 +549,7 @@ final class Charge extends AbstractEntity implements ChargeInterface
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new stdClass();
 

--- a/src/Recurrence/Aggregates/Cycle.php
+++ b/src/Recurrence/Aggregates/Cycle.php
@@ -94,7 +94,7 @@ class Cycle extends AbstractEntity
         return $this->cycleEnd;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return get_object_vars($this);
     }

--- a/src/Recurrence/Aggregates/Increment.php
+++ b/src/Recurrence/Aggregates/Increment.php
@@ -66,7 +66,7 @@ class Increment extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/Invoice.php
+++ b/src/Recurrence/Aggregates/Invoice.php
@@ -238,7 +238,7 @@ class Invoice extends AbstractEntity
         return null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             'subscriptionId' => $this->getSubscriptionId()

--- a/src/Recurrence/Aggregates/Plan.php
+++ b/src/Recurrence/Aggregates/Plan.php
@@ -390,7 +390,7 @@ final class Plan extends AbstractEntity implements RecurrenceEntityInterface, Pr
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/ProductSubscription.php
+++ b/src/Recurrence/Aggregates/ProductSubscription.php
@@ -226,7 +226,7 @@ class ProductSubscription extends AbstractEntity implements ProductSubscriptionI
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/Repetition.php
+++ b/src/Recurrence/Aggregates/Repetition.php
@@ -156,7 +156,7 @@ class Repetition extends AbstractEntity implements RepetitionInterface
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             'id' => $this->getId(),

--- a/src/Recurrence/Aggregates/SubProduct.php
+++ b/src/Recurrence/Aggregates/SubProduct.php
@@ -234,7 +234,7 @@ class SubProduct extends AbstractEntity implements SubProductEntityInterface
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -588,7 +588,7 @@ class Subscription extends AbstractEntity
         return null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/Aggregates/SubscriptionItem.php
+++ b/src/Recurrence/Aggregates/SubscriptionItem.php
@@ -99,7 +99,7 @@ class SubscriptionItem extends AbstractEntity
         $this->updatedAt = $updatedAt;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/ValueObjects/IntervalValueObject.php
+++ b/src/Recurrence/ValueObjects/IntervalValueObject.php
@@ -117,7 +117,7 @@ class IntervalValueObject extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return [
             'intervalType' => $this->getIntervalType(),

--- a/src/Recurrence/ValueObjects/InvoiceStatus.php
+++ b/src/Recurrence/ValueObjects/InvoiceStatus.php
@@ -80,7 +80,7 @@ final class InvoiceStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->getStatus();
     }

--- a/src/Recurrence/ValueObjects/PricingSchemeValueObject.php
+++ b/src/Recurrence/ValueObjects/PricingSchemeValueObject.php
@@ -92,7 +92,7 @@ class PricingSchemeValueObject extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/ValueObjects/SubscriptionStatus.php
+++ b/src/Recurrence/ValueObjects/SubscriptionStatus.php
@@ -86,7 +86,7 @@ final class SubscriptionStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->getStatus();
     }

--- a/src/Webhook/Aggregates/Webhook.php
+++ b/src/Webhook/Aggregates/Webhook.php
@@ -87,8 +87,8 @@ class Webhook extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
-        // TODO: Implement jsonSerialize() method.
+        // TODO: Implement jsonSerialize(): string method.
     }
 }

--- a/src/Webhook/ValueObjects/WebhookType.php
+++ b/src/Webhook/ValueObjects/WebhookType.php
@@ -92,7 +92,7 @@ final class WebhookType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         $obj = new \stdClass();
 

--- a/tests/Hub/Aggregates/InstallTokenTests.php
+++ b/tests/Hub/Aggregates/InstallTokenTests.php
@@ -73,9 +73,9 @@ class InstallTokenTests extends TestCase
         $this->assertInternalType('bool', $this->installToken->isDisabled());
     }
 
-    public function testInstallTokenJsonSerialize()
+    public function testInstallTokenjsonSerialize(): string
     {
-        $this->assertInternalType('object', $this->installToken->jsonSerialize());
-        $this->assertInstanceOf(\stdClass::class, $this->installToken->jsonSerialize());
+        $this->assertInternalType('object', $this->installToken->jsonSerialize(): string);
+        $this->assertInstanceOf(\stdClass::class, $this->installToken->jsonSerialize(): string);
     }
 }

--- a/tests/Kernel/Aggregates/LogObjectTests.php
+++ b/tests/Kernel/Aggregates/LogObjectTests.php
@@ -17,9 +17,9 @@ class LogObjectTests extends TestCase
         $this->logObject = new LogObject();
     }
 
-    public function testJsonSerialize()
+    public function testjsonSerialize(): string
     {
-        $this->assertInternalType('object', $this->logObject->jsonSerialize());
-        $this->assertInstanceOf(\stdClass::class, $this->logObject->jsonSerialize());
+        $this->assertInternalType('object', $this->logObject->jsonSerialize(): string);
+        $this->assertInstanceOf(\stdClass::class, $this->logObject->jsonSerialize(): string);
     }
 }

--- a/tests/Kernel/Factories/Configurations/PixConfigFactoryTest.php
+++ b/tests/Kernel/Factories/Configurations/PixConfigFactoryTest.php
@@ -46,7 +46,7 @@ class PixConfigFactoryTest extends TestCase
             $pixConfig->getAdditionalInformation()
         );
 
-        $serializedPixConfig = $pixConfig->jsonSerialize();
+        $serializedPixConfig = $pixConfig->jsonSerialize(): string;
 
         $this->assertEquals(
             (array) $this->dataWithAdditionalInformation->additionalInformation,
@@ -69,7 +69,7 @@ class PixConfigFactoryTest extends TestCase
             $pixConfig->getAdditionalInformation()
         );
 
-        $serializedPixConfig = $pixConfig->jsonSerialize();
+        $serializedPixConfig = $pixConfig->jsonSerialize(): string;
 
         $this->assertEquals(
             null,

--- a/tests/Recurrence/Aggregates/PlanTest.php
+++ b/tests/Recurrence/Aggregates/PlanTest.php
@@ -21,7 +21,7 @@ class PlanTest extends TestCase
 
     public function testJsonSerializeShouldReturnAnInstanceOfStdClass()
     {
-        $this->assertInstanceOf(\stdClass::class, $this->plan->jsonSerialize());
+        $this->assertInstanceOf(\stdClass::class, $this->plan->jsonSerialize(): string);
     }
 
     public function testJsonSerializeShouldSetAllProperties()

--- a/tests/Recurrence/Aggregates/SubProductTest.php
+++ b/tests/Recurrence/Aggregates/SubProductTest.php
@@ -19,7 +19,7 @@ class SubProductTest extends TestCase
 
     public function testJsonSerializeShouldReturnAnInstanceOfStdClass()
     {
-        $this->assertNotEmpty($this->subProduct->jsonSerialize());
+        $this->assertNotEmpty($this->subProduct->jsonSerialize(): string);
     }
 
     public function testJsonSerializeShouldSetAllProperties()

--- a/tests/Recurrence/ValueObjects/SubscriptionStatusTest.php
+++ b/tests/Recurrence/ValueObjects/SubscriptionStatusTest.php
@@ -34,9 +34,9 @@ class SubscriptionStatusTest extends TestCase
         $this->assertTrue($subscriptionStatusFuture->equals(SubscriptionStatus::future()));
     }
 
-    public function testSubscriptionJsonSerialize()
+    public function testSubscriptionjsonSerialize(): string
     {
-        $subscriptionStatusFuture = SubscriptionStatus::future()->jsonSerialize();
+        $subscriptionStatusFuture = SubscriptionStatus::future()->jsonSerialize(): string;
         $this->assertEquals('future', $subscriptionStatusFuture);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | PHP 8 - returning type
| **What?**         | Define return type to jsonSerialize function
| **Why?**          | To work with php 8

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)
Add additional informations like screenshots, issue link, etc

#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
