### PR TITLE
PAOPN-213 - replace Mundiapi references to PagarmeCoreApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ composer update pagarme/ecommerce-module-core
 
 ## API Reference
 
-[http://docs.mundipagg.com](http://docs.mundipagg.com)
+[https://docs.pagar.me](https://docs.pagar.me)
 
 ## Contributting
 Please, refer to [CONTRIBUTING](.github/CONTRIBUTING.md)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "pagarme/ecommerce-module-core",
   "description": "Core component for Pagar.me e-commerce platform modules.",
   "license": "MIT",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "authors": [
     {
       "name":"Open Source Team"
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=7.1",
     "monolog/monolog": "*",
-    "mundipagg/mundiapi": "^3.0",
+    "pagarme/pagarmecoreapi": "^5.7",
     "ext-json": "*"
   },
   "require-dev": {

--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -4,7 +4,7 @@ namespace Pagarme\Core\Kernel\Abstractions;
 
 use Pagarme\Core\Kernel\Aggregates\Configuration;
 use Pagarme\Core\Kernel\Repositories\ConfigurationRepository;
-use MundiAPILib\Configuration as MundiAPIConfiguration;
+use PagarmeCoreApiLib\Configuration as PagarmeCoreAPIConfiguration;
 use ReflectionClass;
 
 abstract class AbstractModuleCoreSetup
@@ -81,7 +81,7 @@ abstract class AbstractModuleCoreSetup
     protected static function setApiBaseUrl()
     {
         if (static::$moduleConfig->isHubEnabled()) {
-            MundiAPIConfiguration::$BASEURI = 'https://hubapi.mundipagg.com/core/v1';
+            PagarmeCoreAPIConfiguration::$BASEURI = 'https://hubapi.mundipagg.com/core/v1';
         }
     }
 

--- a/src/Kernel/Services/APIService.php
+++ b/src/Kernel/Services/APIService.php
@@ -3,16 +3,16 @@
 namespace Pagarme\Core\Kernel\Services;
 
 use Exception;
-use MundiAPILib\APIException;
-use MundiAPILib\Configuration;
-use MundiAPILib\Controllers\ChargesController;
-use MundiAPILib\Controllers\CustomersController;
-use MundiAPILib\Controllers\OrdersController;
-use MundiAPILib\Exceptions\ErrorException;
-use MundiAPILib\Models\CreateCancelChargeRequest;
-use MundiAPILib\Models\CreateCaptureChargeRequest;
-use MundiAPILib\Models\CreateOrderRequest;
-use MundiAPILib\MundiAPIClient;
+use PagarmeCoreApiLib\APIException;
+use PagarmeCoreApiLib\Configuration;
+use PagarmeCoreApiLib\Controllers\ChargesController;
+use PagarmeCoreApiLib\Controllers\CustomersController;
+use PagarmeCoreApiLib\Controllers\OrdersController;
+use PagarmeCoreApiLib\Exceptions\ErrorException;
+use PagarmeCoreApiLib\Models\CreateCancelChargeRequest;
+use PagarmeCoreApiLib\Models\CreateCaptureChargeRequest;
+use PagarmeCoreApiLib\Models\CreateOrderRequest;
+use PagarmeCoreApiLib\PagarmeCoreApiClient;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
 use Pagarme\Core\Kernel\Aggregates\Charge;
@@ -32,7 +32,7 @@ use Pagarme\Core\Recurrence\Factories\SubscriptionFactory;
 class APIService
 {
     /**
-     * @var MundiAPIClient
+     * @var PagarmeCoreApiClient
      */
     private $apiClient;
 
@@ -53,7 +53,7 @@ class APIService
 
     public function __construct()
     {
-        $this->apiClient = $this->getMundiPaggApiClient();
+        $this->apiClient = $this->getPagarmeCoreApiClient();
         $this->logService = new OrderLogService(2);
         $this->configInfoService = new ConfigInfoRetrieverService();
         $this->orderCreationService = new OrderCreationService($this->apiClient);
@@ -221,7 +221,7 @@ class APIService
         return $this->apiClient->getCustomers();
     }
 
-    private function getMundiPaggApiClient()
+    private function getPagarmeCoreApiClient()
     {
         $i18n = new LocalizationService();
         $config = MPSetup::getModuleConfiguration();
@@ -243,7 +243,7 @@ class APIService
 
         Configuration::$basicAuthPassword = '';
 
-        return new MundiAPIClient($secretKey, $password);
+        return new PagarmeCoreApiClient($secretKey, $password);
     }
 
     private function getAPIBaseEndpoint()

--- a/src/Kernel/Services/ChargeService.php
+++ b/src/Kernel/Services/ChargeService.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Kernel\Services;
 
-use MundiAPILib\Models\GetChargeResponse;
+use PagarmeCoreApiLib\Models\GetChargeResponse;
 use Pagarme\Core\Kernel\Aggregates\Charge;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\Interfaces\ChargeInterface;

--- a/src/Kernel/Services/OrderCreationService.php
+++ b/src/Kernel/Services/OrderCreationService.php
@@ -3,15 +3,15 @@
 namespace Pagarme\Core\Kernel\Services;
 
 use Exception;
-use MundiAPILib\Models\CreateOrderRequest;
-use MundiAPILib\MundiAPIClient;
+use PagarmeCoreApiLib\Models\CreateOrderRequest;
+use PagarmeCoreApiLib\PagarmeCoreApiClient;
 
 class OrderCreationService
 {
     /**
-     * @var MundiAPIClient
+     * @var PagarmeCoreApiClient
      */
-    private $mundiAPIClient;
+    private $pagarmeCoreAPIClient;
 
     /**
      * @var OrderLogService
@@ -23,9 +23,9 @@ class OrderCreationService
      */
     private $generalAttempt = 1;
 
-    public function __construct(MundiAPIClient $mundiAPIClient)
+    public function __construct(PagarmeCoreApiClient $pagarmeCoreAPIClient)
     {
-        $this->mundiAPIClient = $mundiAPIClient;
+        $this->pagarmeCoreAPIClient = $pagarmeCoreAPIClient;
         $this->logService = new OrderLogService(2);
     }
 
@@ -45,7 +45,7 @@ class OrderCreationService
         $response = null;
         $messageLog = "";
 
-        $orderController = $this->mundiAPIClient->getOrders();
+        $orderController = $this->pagarmeCoreAPIClient->getOrders();
 
         try {
             $response = $orderController->createOrder($orderRequest, $idempotencyKey);

--- a/src/Payment/Aggregates/Address.php
+++ b/src/Payment/Aggregates/Address.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates;
 
-use MundiAPILib\Models\CreateAddressRequest;
+use PagarmeCoreApiLib\Models\CreateAddressRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Helper\StringFunctionsHelper;
 use Pagarme\Core\Kernel\Services\LocalizationService;

--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates;
 
-use MundiAPILib\Models\CreateCustomerRequest;
+use PagarmeCoreApiLib\Models\CreateCustomerRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Services\LocalizationService;
 use Pagarme\Core\Payment\Interfaces\ConvertibleToSDKRequestsInterface;

--- a/src/Payment/Aggregates/Item.php
+++ b/src/Payment/Aggregates/Item.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates;
 
-use MundiAPILib\Models\CreateOrderItemRequest;
+use PagarmeCoreApiLib\Models\CreateOrderItemRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Payment\Interfaces\ConvertibleToSDKRequestsInterface;

--- a/src/Payment/Aggregates/Order.php
+++ b/src/Payment/Aggregates/Order.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates;
 
-use MundiAPILib\Models\CreateOrderRequest;
+use PagarmeCoreApiLib\Models\CreateOrderRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Services\LocalizationService;
 use Pagarme\Core\Payment\Aggregates\Payments\AbstractPayment;

--- a/src/Payment/Aggregates/Payments/AbstractCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractCreditCardPayment.php
@@ -2,8 +2,8 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreateCardRequest;
-use MundiAPILib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCardRequest;
+use PagarmeCoreApiLib\Models\CreateCreditCardPaymentRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\Services\InstallmentService;

--- a/src/Payment/Aggregates/Payments/AbstractPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractPayment.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreatePaymentRequest;
+use PagarmeCoreApiLib\Models\CreatePaymentRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Payment\Interfaces\ConvertibleToSDKRequestsInterface;
 use Pagarme\Core\Payment\Interfaces\HaveOrderInterface;

--- a/src/Payment/Aggregates/Payments/BoletoPayment.php
+++ b/src/Payment/Aggregates/Payments/BoletoPayment.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreateBoletoPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateBoletoPaymentRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Payment\Aggregates\Customer;

--- a/src/Payment/Aggregates/Payments/NewCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/NewCreditCardPayment.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCreditCardPaymentRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
 use Pagarme\Core\Payment\ValueObjects\AbstractCardIdentifier;
 use Pagarme\Core\Payment\ValueObjects\CardToken;

--- a/src/Payment/Aggregates/Payments/NewDebitCardPayment.php
+++ b/src/Payment/Aggregates/Payments/NewDebitCardPayment.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCreditCardPaymentRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Payment\ValueObjects\AbstractCardIdentifier;

--- a/src/Payment/Aggregates/Payments/NewVoucherPayment.php
+++ b/src/Payment/Aggregates/Payments/NewVoucherPayment.php
@@ -2,13 +2,13 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCardRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Payment\ValueObjects\AbstractCardIdentifier;
 use Pagarme\Core\Payment\ValueObjects\CardToken;
 use Pagarme\Core\Payment\ValueObjects\PaymentMethod;
-use MundiAPILib\Models\CreateCardRequest;
 
 final class NewVoucherPayment extends AbstractCreditCardPayment
 {

--- a/src/Payment/Aggregates/Payments/PixPayment.php
+++ b/src/Payment/Aggregates/Payments/PixPayment.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreatePixPaymentRequest;
+use PagarmeCoreApiLib\Models\CreatePixPaymentRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Payment\ValueObjects\PaymentMethod;
 

--- a/src/Payment/Aggregates/Payments/SavedCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedCreditCardPayment.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCreditCardPaymentRequest;
 use Pagarme\Core\Kernel\ValueObjects\Id\CustomerId;
 use Pagarme\Core\Payment\ValueObjects\AbstractCardIdentifier;
 use Pagarme\Core\Payment\ValueObjects\CardId;

--- a/src/Payment/Aggregates/Payments/SavedDebitCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedDebitCardPayment.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCreditCardPaymentRequest;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\ValueObjects\Id\CustomerId;
 use Pagarme\Core\Payment\ValueObjects\AbstractCardIdentifier;

--- a/src/Payment/Aggregates/Payments/SavedVoucherCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedVoucherCardPayment.php
@@ -2,13 +2,13 @@
 
 namespace Pagarme\Core\Payment\Aggregates\Payments;
 
-use MundiAPILib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCreditCardPaymentRequest;
+use PagarmeCoreApiLib\Models\CreateCardRequest;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\ValueObjects\Id\CustomerId;
 use Pagarme\Core\Payment\ValueObjects\AbstractCardIdentifier;
 use Pagarme\Core\Payment\ValueObjects\CardId;
 use Pagarme\Core\Payment\ValueObjects\PaymentMethod;
-use MundiAPILib\Models\CreateCardRequest;
 
 final class SavedVoucherCardPayment extends AbstractCreditCardPayment
 {

--- a/src/Payment/Aggregates/Shipping.php
+++ b/src/Payment/Aggregates/Shipping.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\Aggregates;
 
-use MundiAPILib\Models\CreateShippingRequest;
+use PagarmeCoreApiLib\Models\CreateShippingRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Payment\Interfaces\ConvertibleToSDKRequestsInterface;
 use Pagarme\Core\Payment\Traits\WithAmountTrait;

--- a/src/Payment/Factories/PaymentFactory.php
+++ b/src/Payment/Factories/PaymentFactory.php
@@ -166,7 +166,7 @@ final class PaymentFactory
 
         $payments = [];
         foreach ($cardsData as $cardData) {
-            $payments[] = $this->createBaseCardPayment(
+            $payments[] = $this->createBasePayments(
                 $cardData,
                 $cardDataIndex,
                 $config

--- a/src/Payment/ValueObjects/CustomerPhones.php
+++ b/src/Payment/ValueObjects/CustomerPhones.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Payment\ValueObjects;
 
-use MundiAPILib\Models\CreatePhonesRequest;
+use PagarmeCoreApiLib\Models\CreatePhonesRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractValueObject;
 use Pagarme\Core\Payment\Interfaces\ConvertibleToSDKRequestsInterface;
 

--- a/src/Payment/ValueObjects/Phone.php
+++ b/src/Payment/ValueObjects/Phone.php
@@ -3,7 +3,7 @@
 namespace Pagarme\Core\Payment\ValueObjects;
 
 
-use MundiAPILib\Models\CreatePhoneRequest;
+use PagarmeCoreApiLib\Models\CreatePhoneRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractValueObject;
 use Pagarme\Core\Kernel\ValueObjects\NumericString;
 use Pagarme\Core\Payment\Interfaces\ConvertibleToSDKRequestsInterface;

--- a/src/Recurrence/Aggregates/Increment.php
+++ b/src/Recurrence/Aggregates/Increment.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Recurrence\Aggregates;
 
-use MundiAPILib\Models\CreateIncrementRequest;
+use PagarmeCoreApiLib\Models\CreateIncrementRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 
 class Increment extends AbstractEntity

--- a/src/Recurrence/Aggregates/Plan.php
+++ b/src/Recurrence/Aggregates/Plan.php
@@ -2,8 +2,8 @@
 
 namespace Pagarme\Core\Recurrence\Aggregates;
 
-use MundiAPILib\Models\CreatePlanRequest;
-use MundiAPILib\Models\UpdatePlanRequest;
+use PagarmeCoreApiLib\Models\CreatePlanRequest;
+use PagarmeCoreApiLib\Models\UpdatePlanRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Recurrence\Interfaces\RecurrenceEntityInterface;

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -2,8 +2,8 @@
 
 namespace Pagarme\Core\Recurrence\Aggregates;
 
-use MundiAPILib\Models\CreateCardRequest;
-use MundiAPILib\Models\CreateSubscriptionRequest;
+use PagarmeCoreApiLib\Models\CreateCardRequest;
+use PagarmeCoreApiLib\Models\CreateSubscriptionRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Aggregates\Order;
 use Pagarme\Core\Kernel\Interfaces\ChargeInterface;

--- a/src/Recurrence/Factories/InvoiceFactory.php
+++ b/src/Recurrence/Factories/InvoiceFactory.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Recurrence\Factories;
 
-use MundiAPILib\Models\ListInvoicesResponse;
+use PagarmeCoreApiLib\Models\ListInvoicesResponse;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Recurrence\Aggregates\Charge;
 use Pagarme\Core\Kernel\Interfaces\FactoryInterface;

--- a/src/Recurrence/Services/PlanService.php
+++ b/src/Recurrence/Services/PlanService.php
@@ -2,14 +2,14 @@
 
 namespace Pagarme\Core\Recurrence\Services;
 
-use MundiAPILib\Models\GetPlanItemResponse;
-use MundiAPILib\MundiAPIClient;
+use PagarmeCoreApiLib\Models\GetPlanItemResponse;
+use PagarmeCoreApiLib\PagarmeCoreApiClient;
+use PagarmeCoreApiLib\Models\CreatePlanRequest;
 use Pagarme\Core\Kernel\Services\LogService;
 use Pagarme\Core\Kernel\ValueObjects\AbstractValidString;
 use Pagarme\Core\Recurrence\Aggregates\Plan;
 use Pagarme\Core\Recurrence\Factories\PlanFactory;
 use Pagarme\Core\Recurrence\Repositories\PlanRepository;
-use MundiAPILib\Models\CreatePlanRequest;
 use Pagarme\Core\Recurrence\ValueObjects\PlanId;
 use Pagarme\Core\Recurrence\ValueObjects\PlanItemId;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup;
@@ -29,9 +29,9 @@ class PlanService
 
         $password = '';
 
-        \MundiAPILib\Configuration::$basicAuthPassword = '';
+        \PagarmeCoreApiLib\Configuration::$basicAuthPassword = '';
 
-        $this->mundipaggApi = new MundiAPIClient($secretKey, $password);
+        $this->pagarmeCoreApiClient = new PagarmeCoreApiClient($secretKey, $password);
     }
 
     /**
@@ -57,7 +57,7 @@ class PlanService
     public function createPlanAtPagarme(Plan $plan)
     {
         $createPlanRequest = $plan->convertToSdkRequest();
-        $planController = $this->mundipaggApi->getPlans();
+        $planController = $this->pagarmeCoreApiClient->getPlans();
 
         try {
             $logService = $this->getLogService();
@@ -86,7 +86,7 @@ class PlanService
     public function updatePlanAtPagarme(Plan $plan)
     {
         $updatePlanRequest = $plan->convertToSdkRequest(true);
-        $planController = $this->mundipaggApi->getPlans();
+        $planController = $this->pagarmeCoreApiClient->getPlans();
 
         $this->updateItemsAtPagarme($plan, $planController);
         $result = $planController->updatePlan($plan->getPagarmeId(), $updatePlanRequest);
@@ -168,7 +168,7 @@ class PlanService
         }
 
         try {
-            $planController = $this->mundipaggApi->getPlans();
+            $planController = $this->pagarmeCoreApiClient->getPlans();
             $planController->deletePlan($plan->getPagarmeId());
         } catch (\Exception $exception) {
             return $exception->getMessage();
@@ -182,9 +182,9 @@ class PlanService
         return new PlanRepository();
     }
 
-    public function getMundiAPIClient($secretKey, $password)
+    public function getPagarmeCoreAPIClient($secretKey, $password)
     {
-        return new MundiAPIClient($secretKey, $password);
+        return new PagarmeCoreAPIClient($secretKey, $password);
     }
 
     public function getLogService()

--- a/tests/Recurrence/Aggregates/IncrementTest.php
+++ b/tests/Recurrence/Aggregates/IncrementTest.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Test\Recurrence\Aggregates;
 
-use MundiAPILib\Models\CreateIncrementRequest;
+use PagarmeCoreApiLib\Models\CreateIncrementRequest;
 use Pagarme\Core\Recurrence\Aggregates\Increment;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Recurrence/Aggregates/PlanTest.php
+++ b/tests/Recurrence/Aggregates/PlanTest.php
@@ -2,13 +2,13 @@
 
 namespace Pagarme\Core\Test\Recurrence\Aggregates;
 
-use MundiAPILib\Models\CreatePlanRequest;
-use MundiAPILib\Models\UpdatePlanRequest;
+use PagarmeCoreApiLib\Models\CreatePlanRequest;
+use PagarmeCoreApiLib\Models\UpdatePlanRequest;
 use Pagarme\Core\Recurrence\Aggregates\Plan;
 use Pagarme\Core\Recurrence\Aggregates\SubProduct;
 use Pagarme\Core\Recurrence\ValueObjects\PlanId;
-use PHPUnit\Framework\TestCase;
 use Pagarme\Core\Recurrence\ValueObjects\IntervalValueObject;
+use PHPUnit\Framework\TestCase;
 
 class PlanTest extends TestCase
 {

--- a/tests/Recurrence/Aggregates/SubscriptionTest.php
+++ b/tests/Recurrence/Aggregates/SubscriptionTest.php
@@ -3,9 +3,9 @@
 namespace Pagarme\Core\Test\Recurrence\Aggregates;
 
 use Mockery;
-use MundiAPILib\Models\CreateAddressRequest;
-use MundiAPILib\Models\CreateCardRequest;
-use MundiAPILib\Models\CreateSubscriptionRequest;
+use PagarmeCoreApiLib\Models\CreateAddressRequest;
+use PagarmeCoreApiLib\Models\CreateCardRequest;
+use PagarmeCoreApiLib\Models\CreateSubscriptionRequest;
 use Pagarme\Core\Kernel\Interfaces\PlatformOrderInterface;
 use Pagarme\Core\Kernel\ValueObjects\Id\ChargeId;
 use Pagarme\Core\Kernel\ValueObjects\Id\SubscriptionId;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-213
| **What?**         | Replace MundiApi references to PagarmeCoreApi.
| **Why?**          | MundiApi is discontinued
| **How?**          | Replace the package mundipagg/mundiapi references to pagarme/pagarmecoreapi