### PR TITLE
Bug fix allowing checkout when shipping is empty

### DIFF
--- a/src/Kernel/Services/OrderService.php
+++ b/src/Kernel/Services/OrderService.php
@@ -391,7 +391,7 @@ final class OrderService
         $order->setCode($platformOrder->getCode());
 
         $shipping = $platformOrder->getShipping();
-        if ($shipping !== null) {
+        if (!$shipping && $shipping !== null) {
             $order->setShipping($shipping);
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-280
| **What?**         | Added a bypass to checkout with blank shipping information.
| **Why?**          | Could not finish checkout when shipping information was blank.
| **How?**          | Edited a `if` statement that already checked if shipping is `null`, to also check if it is blank.