### PR TITLE
Bug fix editing customer through admin

### DIFF
--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -47,7 +47,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setCode($code)
     {
-        $this->code = substr($code, 0, 52);
+        $this->code = substr($code ?? "", 0, 52);
     }
 
     /**
@@ -64,7 +64,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setName($name)
     {
-        $this->name = substr($name, 0, 64);
+        $this->name = substr($name ?? "", 0, 64);
     }
 
     /**
@@ -83,7 +83,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
     public function setEmail($email)
     {
         $email = trim($email);
-        $email = substr($email, 0, 64);
+        $email = substr($email ?? "", 0, 64);
 
         $this->validateEmail($email);
         $this->email = $email;
@@ -124,7 +124,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
     {
         $this->document = $this->formatDocument($document);
 
-        if (empty($this->document)) {
+        if (empty($this->document) && empty($this->getPagarmeId())) {
 
             $inputName = $this->i18n->getDashboard('document');
             $message = $this->i18n->getDashboard(
@@ -228,8 +228,10 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
         $customerRequest->code = $this->getCode();
         $customerRequest->name = $this->getName();
         $customerRequest->email = $this->getEmail();
-        $customerRequest->document = $this->getDocument();
-        $customerRequest->type = $this->getTypeValue();
+        if ($this->getDocument()) {
+            $customerRequest->document = $this->getDocument();
+            $customerRequest->type = $this->getTypeValue();
+        }
         $customerRequest->address = $this->getAddressToSDK();
         $customerRequest->phones = $this->getPhonesToSDK();
 
@@ -261,7 +263,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
     {
         $document = preg_replace(
             '/[^0-9]/is', '',
-            substr($document, 0, 16)
+            substr($document ?? "", 0, 16)
         );
 
         return $document;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-273
| **What?**         | Error when creating/editing customer data through the administrative portal.
| **Why?**          | Editing client info through admin was causing a error
| **How?**          | Check if the customer already exists at Pagar.Me, if it already exists, perform the validation ignoring the 'document' field if it is blank, if it does not exist, do not update the customer data in Pagar.Me