### PR TITLE
:heavy_plus_sign: apply canceled status to subscriptions when receiving chargeback

### DIFF
--- a/src/Kernel/ValueObjects/ChargeStatus.php
+++ b/src/Kernel/ValueObjects/ChargeStatus.php
@@ -46,6 +46,7 @@ final class ChargeStatus extends AbstractValueObject
     {
         return new self(self::CANCELED);
     }
+    
     static public function chargedback()
     {
         return new self(self::CHARGEDBACK);

--- a/src/Kernel/ValueObjects/ChargeStatus.php
+++ b/src/Kernel/ValueObjects/ChargeStatus.php
@@ -11,6 +11,7 @@ final class ChargeStatus extends AbstractValueObject
     const CANCELED = 'canceled';
     const PROCESSING = 'processing';
     const FAILED = 'failed';
+    const CHARGEDBACK = 'chargedback';
 
     const UNDERPAID = 'underpaid';
     const OVERPAID = 'overpaid';
@@ -44,6 +45,10 @@ final class ChargeStatus extends AbstractValueObject
     static public function canceled()
     {
         return new self(self::CANCELED);
+    }
+    static public function chargedback()
+    {
+        return new self(self::CHARGEDBACK);
     }
 
     static public function underpaid()

--- a/src/Kernel/ValueObjects/TransactionStatus.php
+++ b/src/Kernel/ValueObjects/TransactionStatus.php
@@ -114,10 +114,12 @@ final class TransactionStatus extends AbstractValueObject
     {
         return new self(self::FAILED);
     }
+
     public static function chargedback()
     {
         return new self(self::CHARGEDBACK);
     }
+    
     public static function waitingPayment()
     {
         return new self(self::WAITING_PAYMENT);

--- a/src/Kernel/ValueObjects/TransactionStatus.php
+++ b/src/Kernel/ValueObjects/TransactionStatus.php
@@ -15,6 +15,7 @@ final class TransactionStatus extends AbstractValueObject
     const WITH_ERROR = 'withError';
     const NOT_AUTHORIZED = 'notAuthorized';
     const FAILED = 'failed';
+    const CHARGEDBACK = 'chargedback';
 
     const GENERATED = 'generated';
     const UNDERPAID = 'underpaid';
@@ -113,7 +114,10 @@ final class TransactionStatus extends AbstractValueObject
     {
         return new self(self::FAILED);
     }
-
+    public static function chargedback()
+    {
+        return new self(self::CHARGEDBACK);
+    }
     public static function waitingPayment()
     {
         return new self(self::WAITING_PAYMENT);

--- a/src/Recurrence/Aggregates/Charge.php
+++ b/src/Recurrence/Aggregates/Charge.php
@@ -165,6 +165,11 @@ final class Charge extends AbstractEntity implements ChargeInterface
         $this->status = ChargeStatus::canceled();
     }
 
+    public function chargedback()
+    {
+        $this->status = ChargeStatus::canceled();
+    }
+
     /**
      *
      * @return int

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -447,6 +447,7 @@ class Subscription extends AbstractEntity
 
         return $this;
     }
+
     public function updateCharge(ChargeInterface $updatedCharge, $overwriteId = false)
     {
         $charges = $this->getCharges();
@@ -467,7 +468,11 @@ class Subscription extends AbstractEntity
     }
 
 
-
+    /**
+     * Undocumented function
+     *
+     * @return void
+     */
     public function applyOrderStatusFromCharges()
     {
         if (empty($this->getCharges())) {
@@ -503,7 +508,6 @@ class Subscription extends AbstractEntity
         ) {
             $this->setStatus(SubscriptionStatus::canceled());
         }
-        $data = $listChargeStatus;
         if (
             in_array(ChargeStatus::chargedback()->getStatus(), $listChargeStatus)
         ) {
@@ -518,6 +522,7 @@ class Subscription extends AbstractEntity
             $this->setStatus(SubscriptionStatus::$currentStatus());
         }
     }
+    
     /**
      * @param ChargeInterface[] $charges
      */

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -19,6 +19,7 @@ use Pagarme\Core\Recurrence\ValueObjects\PlanId;
 use Pagarme\Core\Recurrence\ValueObjects\IntervalValueObject;
 use Pagarme\Core\Recurrence\Aggregates\SubProduct;
 use Pagarme\Core\Recurrence\Aggregates\Invoice;
+use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
 
 class Subscription extends AbstractEntity
 {
@@ -446,7 +447,77 @@ class Subscription extends AbstractEntity
 
         return $this;
     }
+    public function updateCharge(ChargeInterface $updatedCharge, $overwriteId = false)
+    {
+        $charges = $this->getCharges();
 
+        foreach ($charges as &$charge) {
+            if ($charge->getPagarmeId()->equals($updatedCharge->getPagarmeId())) {
+                $chargeId = $charge->getId();
+                $charge = $updatedCharge;
+                if ($overwriteId) {
+                    $charge->setId($chargeId);
+                }
+                $this->charges = $charges;
+                return;
+            }
+        }
+
+        $this->addCharge($updatedCharge);
+    }
+
+
+
+    public function applyOrderStatusFromCharges()
+    {
+        if (empty($this->getCharges())) {
+            return;
+        }
+
+        $listChargeStatus = [];
+        foreach ($this->getCharges() as $charge) {
+            $listChargeStatus[$charge->getStatus()->getStatus()] =
+                $charge->getStatus()->getStatus();
+        }
+
+        $chargesStatusEquals = count($listChargeStatus) == 1;
+
+        if (
+            $chargesStatusEquals &&
+            $this->getCharges()[0]->getStatus()->equals(ChargeStatus::overpaid())
+        ) {
+            $this->setStatus(SubscriptionStatus::paid());
+            return;
+        }
+
+        if (
+            in_array(ChargeStatus::paid()->getStatus(), $listChargeStatus) &&
+            in_array(ChargeStatus::overpaid()->getStatus(), $listChargeStatus)
+        ) {
+            $this->setStatus(SubscriptionStatus::paid());
+        }
+
+        if (
+            in_array(ChargeStatus::failed()->getStatus(), $listChargeStatus) &&
+            in_array(ChargeStatus::canceled()->getStatus(), $listChargeStatus)
+        ) {
+            $this->setStatus(SubscriptionStatus::canceled());
+        }
+        $data = $listChargeStatus;
+        if (
+            in_array(ChargeStatus::chargedback()->getStatus(), $listChargeStatus)
+        ) {
+            $this->setStatus(SubscriptionStatus::canceled());
+        }
+
+        if (
+            $chargesStatusEquals &&
+            !$this->getCharges()[0]->getStatus()->equals(ChargeStatus::underpaid())
+        ) {
+            $currentStatus = reset($listChargeStatus);
+            $this->setStatus(SubscriptionStatus::$currentStatus());
+        }
+    }
     /**
      * @param ChargeInterface[] $charges
      */

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -467,12 +467,6 @@ class Subscription extends AbstractEntity
         $this->addCharge($updatedCharge);
     }
 
-
-    /**
-     * Undocumented function
-     *
-     * @return void
-     */
     public function applyOrderStatusFromCharges()
     {
         if (empty($this->getCharges())) {

--- a/src/Recurrence/ValueObjects/SubscriptionStatus.php
+++ b/src/Recurrence/ValueObjects/SubscriptionStatus.php
@@ -10,6 +10,7 @@ final class SubscriptionStatus extends AbstractValueObject
     const CANCELED = 'canceled';
     const FUTURE = 'future';
     const FAILED = 'failed';
+    const CHARGEDBACK = 'chargedback';
 
     /**
      * @var string
@@ -44,6 +45,10 @@ final class SubscriptionStatus extends AbstractValueObject
     public static function failed()
     {
         return new self(self::FAILED);
+    }
+    public static function chargedback()
+    {
+        return new self(self::CHARGEDBACK);
     }
 
     /**

--- a/src/Recurrence/ValueObjects/SubscriptionStatus.php
+++ b/src/Recurrence/ValueObjects/SubscriptionStatus.php
@@ -46,6 +46,7 @@ final class SubscriptionStatus extends AbstractValueObject
     {
         return new self(self::FAILED);
     }
+    
     public static function chargedback()
     {
         return new self(self::CHARGEDBACK);

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -265,6 +265,10 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         return $result;
     }
 
+    /**
+     * @param Webhook $webhook
+     * @return array
+     */
     protected function handleChargedback(Webhook $webhook)
     {
         

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -16,9 +16,11 @@ use Pagarme\Core\Kernel\Services\OrderService;
 use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
 use Pagarme\Core\Kernel\ValueObjects\Id\SubscriptionId;
 use Pagarme\Core\Kernel\ValueObjects\OrderStatus;
+use Pagarme\Core\Kernel\ValueObjects\TransactionStatus;
 use Pagarme\Core\Recurrence\Repositories\ChargeRepository;
 use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
 use Pagarme\Core\Webhook\Aggregates\Webhook;
+use Pagarme\Core\Recurrence\ValueObjects\SubscriptionStatus;
 
 final class ChargeRecurrenceService extends AbstractHandlerService
 {
@@ -261,6 +263,56 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         ];
 
         return $result;
+    }
+
+    protected function handleChargedback(Webhook $webhook)
+    {
+        
+        $order = $this->order;
+        
+        $subscriptionRepository = new SubscriptionRepository();
+        $i18n = new LocalizationService();
+
+        /**
+         * @var Charge $charge
+         */
+        $charge = $webhook->getEntity();
+
+        $transaction = $charge->getLastTransaction();
+        
+        $outdatedCharge = $this->chargeRepository->findByPagarmeId(
+            $charge->getPagarmeId()
+        );
+
+        if ($outdatedCharge !== null) {
+            $charge = $outdatedCharge;
+        }
+         /**
+         * @var Charge $outdatedCharge
+         */
+        if ($transaction !== null) {
+            $outdatedCharge->addTransaction($transaction);
+        }
+
+        $charge->chargedback();
+        $order->updateCharge($charge);
+        $order->applyOrderStatusFromCharges();
+
+
+        $this->order->setStatus(SubscriptionStatus::canceled());
+
+        $subscriptionRepository->save($this->order);
+
+        $history = $i18n->getDashboard('Subscription canceled');
+        $this->order->getPlatformOrder()->addHistoryComment($history);
+
+        $this->orderService->syncPlatformWith($order, false);
+        
+        return [
+            "message" => 'Subscription cancel registered',
+            "code" => 200
+        ];
+
     }
 
     //@todo handleProcessing


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-283
| **What?**         | Apply canceled status to subscriptions when receiving chargeback
| **Why?**          | To handle the chargeback charge
| **How?**          | It implements the treatment where when you receive the charge.chargedback of the subscription, you cancel it.
