### PR TITLE
:heavy_plus_sign: assigns chargeback status to invoices

### DIFF
--- a/src/Recurrence/Aggregates/Charge.php
+++ b/src/Recurrence/Aggregates/Charge.php
@@ -167,7 +167,7 @@ final class Charge extends AbstractEntity implements ChargeInterface
 
     public function chargedback()
     {
-        $this->status = ChargeStatus::canceled();
+        $this->status = ChargeStatus::chargedback();
     }
 
     /**

--- a/src/Recurrence/Services/InvoiceService.php
+++ b/src/Recurrence/Services/InvoiceService.php
@@ -6,6 +6,7 @@ use Pagarme\Core\Kernel\Services\APIService;
 use Pagarme\Core\Kernel\Services\LogService;
 use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
 use Pagarme\Core\Payment\Services\ResponseHandlers\ErrorExceptionHandler;
+use Pagarme\Core\Recurrence\Aggregates\Charge;
 use Pagarme\Core\Recurrence\Aggregates\Invoice;
 use Pagarme\Core\Recurrence\Factories\ChargeFactory;
 use Pagarme\Core\Recurrence\Factories\InvoiceFactory;
@@ -117,6 +118,12 @@ class InvoiceService
         );
 
         return $apiService->cancelInvoice($invoice);
+    }
+
+    public function setChargedbackStatus(Charge $charge)
+    {
+        $charge->setMetadata(json_decode($charge->getMetadata()));
+        $this->getChargeRepository()->save($charge);
     }
 
     public function getApiService()

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -308,8 +308,8 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         
         $history = $i18n->getDashboard('Subscription canceled');
         $order->getPlatformOrder()->addHistoryComment($history);
-        
-        $subscriptionRepository->save($this->order);
+
+        $subscriptionRepository->save($order);
         
         return [
             "message" => 'Subscription cancel registered',

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -19,8 +19,8 @@ use Pagarme\Core\Kernel\ValueObjects\OrderStatus;
 use Pagarme\Core\Kernel\ValueObjects\TransactionStatus;
 use Pagarme\Core\Recurrence\Repositories\ChargeRepository;
 use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
+use Pagarme\Core\Recurrence\Services\InvoiceService;
 use Pagarme\Core\Webhook\Aggregates\Webhook;
-use Pagarme\Core\Recurrence\ValueObjects\SubscriptionStatus;
 
 final class ChargeRecurrenceService extends AbstractHandlerService
 {
@@ -273,7 +273,7 @@ final class ChargeRecurrenceService extends AbstractHandlerService
     {
         
         $order = $this->order;
-        
+        $invoiceService = new InvoiceService();
         $subscriptionRepository = new SubscriptionRepository();
         $i18n = new LocalizationService();
 
@@ -298,19 +298,18 @@ final class ChargeRecurrenceService extends AbstractHandlerService
             $outdatedCharge->addTransaction($transaction);
         }
 
-        $charge->chargedback();
+        
+        $charge->cancel();
         $order->updateCharge($charge);
         $order->applyOrderStatusFromCharges();
-
-
-        $this->order->setStatus(SubscriptionStatus::canceled());
-
-        $subscriptionRepository->save($this->order);
-
+        
+        $charge->chargedback();
+        $invoiceService->setChargedbackStatus($charge);
+        
         $history = $i18n->getDashboard('Subscription canceled');
-        $this->order->getPlatformOrder()->addHistoryComment($history);
-
-        $this->orderService->syncPlatformWith($order, false);
+        $order->getPlatformOrder()->addHistoryComment($history);
+        
+        $subscriptionRepository->save($this->order);
         
         return [
             "message" => 'Subscription cancel registered',


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-269
| **What?**         | Assigns chargedback status to invoices on recurrence
| **Why?**          | To assign the same status as dash
| **How?**          | When the webhook receives the charge.chagedback
