### PR TITLE
PAOPN-288: adjusting compatibility between php 7 and php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "pagarme/ecommerce-module-core",
   "description": "Core component for Pagar.me e-commerce platform modules.",
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "2.1.0",
   "authors": [
     {
       "name":"Open Source Team"
@@ -11,7 +11,7 @@
   "type": "library",
   "require": {
     "php": ">=7.1",
-    "monolog/monolog": "<3",
+    "monolog/monolog": "~2",
     "pagarme/pagarmecoreapi": "^5.7",
     "ext-json": "*"
   },
@@ -37,5 +37,10 @@
     ],
     "tests": "vendor/bin/phpunit --colors=always",
     "tests-coverage": "vendor/bin/phpunit --colors=always --coverage-html ./tests/report"
+  },
+  "config": {
+    "allow-plugins": {
+      "kylekatarnls/update-helper": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "type": "library",
   "require": {
     "php": ">=7.1",
-    "monolog/monolog": "*",
+    "monolog/monolog": "<3",
     "pagarme/pagarmecoreapi": "^5.7",
     "ext-json": "*"
   },
@@ -19,7 +19,7 @@
     "mockery/mockery": "1.2.4",
     "nesbot/carbon": "1.39.0",
     "ext-pdo": "*",
-    "phpunit/phpunit": "5.7.27"
+    "phpunit/phpunit": "^5 | ^6 | ^7 | ^8 | ^9"
   },
   "autoload": {
     "psr-4": {

--- a/src/Hub/Aggregates/InstallToken.php
+++ b/src/Hub/Aggregates/InstallToken.php
@@ -136,7 +136,7 @@ final class InstallToken extends AbstractEntity
      *
      * @return array|mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Hub/Aggregates/InstallToken.php
+++ b/src/Hub/Aggregates/InstallToken.php
@@ -132,11 +132,8 @@ final class InstallToken extends AbstractEntity
     {
     }
 
-    /**
-     *
-     * @return array|mixed
-     */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Hub/Commands/CommandType.php
+++ b/src/Hub/Commands/CommandType.php
@@ -72,7 +72,8 @@ final class CommandType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->value;
     }

--- a/src/Hub/Commands/CommandType.php
+++ b/src/Hub/Commands/CommandType.php
@@ -12,7 +12,7 @@ final class CommandType extends AbstractValueObject
 
     /**
      *
-     * @var string 
+     * @var string
      */
     private $value;
 
@@ -58,7 +58,7 @@ final class CommandType extends AbstractValueObject
 
     /**
      *
-     * @var static $object 
+     * @var static $object
      */
     public function isEqual($object)
     {
@@ -72,7 +72,7 @@ final class CommandType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->value;
     }

--- a/src/Kernel/Aggregates/Charge.php
+++ b/src/Kernel/Aggregates/Charge.php
@@ -456,7 +456,8 @@ final class Charge extends AbstractEntity implements ChargeInterface
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Aggregates/Charge.php
+++ b/src/Kernel/Aggregates/Charge.php
@@ -17,17 +17,17 @@ final class Charge extends AbstractEntity implements ChargeInterface
 
     /**
      *
-     * @var OrderId 
+     * @var OrderId
      */
     private $orderId;
     /**
      *
-     * @var int 
+     * @var int
      */
     private $amount;
     /**
      *
-     * @var int 
+     * @var int
      */
     private $paidAmount;
     /**
@@ -45,18 +45,18 @@ final class Charge extends AbstractEntity implements ChargeInterface
 
     /**
      *
-     * @var string 
+     * @var string
      */
     private $code;
     /**
      *
-     * @var ChargeStatus 
+     * @var ChargeStatus
      */
     private $status;
 
     /**
      *
-     * @var Transaction[] 
+     * @var Transaction[]
      */
     private $transactions;
 
@@ -456,7 +456,7 @@ final class Charge extends AbstractEntity implements ChargeInterface
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -733,7 +733,8 @@ final class Configuration extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -705,7 +705,7 @@ final class Configuration extends AbstractEntity
         if (!is_numeric($boletoDueDays)) {
             throw new InvalidParamException("Boleto due days should be an integer!", $boletoDueDays);
         }
-        
+
         $this->boletoDueDays = (int) $boletoDueDays;
     }
 
@@ -733,7 +733,7 @@ final class Configuration extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/Aggregates/LogObject.php
+++ b/src/Kernel/Aggregates/LogObject.php
@@ -96,7 +96,8 @@ final class LogObject extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $baseObject = new \stdClass();
 

--- a/src/Kernel/Aggregates/LogObject.php
+++ b/src/Kernel/Aggregates/LogObject.php
@@ -96,7 +96,7 @@ final class LogObject extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $baseObject = new \stdClass();
 

--- a/src/Kernel/Aggregates/Order.php
+++ b/src/Kernel/Aggregates/Order.php
@@ -200,7 +200,8 @@ final class Order extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Aggregates/Order.php
+++ b/src/Kernel/Aggregates/Order.php
@@ -15,18 +15,18 @@ final class Order extends AbstractEntity
 
     /**
      *
-     * @var PlatformOrderInterface 
+     * @var PlatformOrderInterface
      */
     private $platformOrder;
 
     /**
      *
-     * @var OrderStatus 
+     * @var OrderStatus
      */
     private $status;
     /**
      *
-     * @var Charge[] 
+     * @var Charge[]
      */
     private $charges;
 
@@ -170,7 +170,7 @@ final class Order extends AbstractEntity
         $charges[] = $newCharge;
         $this->charges = $charges;
 
-        return $this;  
+        return $this;
     }
 
     public function updateCharge(ChargeInterface $updatedCharge, $overwriteId = false)
@@ -200,7 +200,7 @@ final class Order extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Aggregates/Transaction.php
+++ b/src/Kernel/Aggregates/Transaction.php
@@ -398,7 +398,8 @@ final class Transaction extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Aggregates/Transaction.php
+++ b/src/Kernel/Aggregates/Transaction.php
@@ -18,7 +18,7 @@ final class Transaction extends AbstractEntity
     private $transactionType;
     /**
      *
-     * @var int 
+     * @var int
      */
     private $amount;
     /**
@@ -29,23 +29,23 @@ final class Transaction extends AbstractEntity
 
     /**
      *
-     * @var TransactionStatus 
+     * @var TransactionStatus
      */
     private $status;
     /**
      *
-     * @var \DateTime 
+     * @var \DateTime
      */
     private $createdAt;
     /**
      *
-     * @var ChargeId 
+     * @var ChargeId
      */
     private $chargeId;
 
     /**
      *
-     * @var string 
+     * @var string
      */
     private $acquirerName;
     /**
@@ -65,19 +65,19 @@ final class Transaction extends AbstractEntity
     private $acquirerAuthCode;
     /**
      *
-     * @var string 
+     * @var string
      */
     private $acquirerMessage;
 
     /**
      *
-     * @var string 
+     * @var string
      */
     private $brand;
 
     /**
      *
-     * @var int 
+     * @var int
      */
     private $installments;
 
@@ -398,7 +398,7 @@ final class Transaction extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Exceptions/AbstractPagarmeCoreException.php
+++ b/src/Kernel/Exceptions/AbstractPagarmeCoreException.php
@@ -17,7 +17,7 @@ abstract class AbstractPagarmeCoreException
       * which is a value of any type other than a resource.
       * @since  5.4.0
       */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/Exceptions/AbstractPagarmeCoreException.php
+++ b/src/Kernel/Exceptions/AbstractPagarmeCoreException.php
@@ -17,7 +17,8 @@ abstract class AbstractPagarmeCoreException
       * which is a value of any type other than a resource.
       * @since  5.4.0
       */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/AbstractValidString.php
+++ b/src/Kernel/ValueObjects/AbstractValidString.php
@@ -9,7 +9,7 @@ abstract class AbstractValidString extends AbstractValueObject
 {
     /**
      *
-     * @var string 
+     * @var string
      */
     protected $value;
 
@@ -47,7 +47,7 @@ abstract class AbstractValidString extends AbstractValueObject
             $this->value = $value;
             return $this;
         }
-        
+
         throw new InvalidParamException("Invalid value for " . static::class . "!", $value);
     }
 
@@ -73,7 +73,7 @@ abstract class AbstractValidString extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getValue();
     }

--- a/src/Kernel/ValueObjects/AbstractValidString.php
+++ b/src/Kernel/ValueObjects/AbstractValidString.php
@@ -66,14 +66,15 @@ abstract class AbstractValidString extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->getValue();
     }

--- a/src/Kernel/ValueObjects/CardBrand.php
+++ b/src/Kernel/ValueObjects/CardBrand.php
@@ -179,7 +179,7 @@ final class CardBrand extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getName();
     }

--- a/src/Kernel/ValueObjects/CardBrand.php
+++ b/src/Kernel/ValueObjects/CardBrand.php
@@ -172,14 +172,15 @@ final class CardBrand extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->getName();
     }

--- a/src/Kernel/ValueObjects/ChargeStatus.php
+++ b/src/Kernel/ValueObjects/ChargeStatus.php
@@ -105,14 +105,15 @@ final class ChargeStatus extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->status;
     }

--- a/src/Kernel/ValueObjects/ChargeStatus.php
+++ b/src/Kernel/ValueObjects/ChargeStatus.php
@@ -46,6 +46,7 @@ final class ChargeStatus extends AbstractValueObject
     {
         return new self(self::CANCELED);
     }
+    
     static public function chargedback()
     {
         return new self(self::CHARGEDBACK);

--- a/src/Kernel/ValueObjects/ChargeStatus.php
+++ b/src/Kernel/ValueObjects/ChargeStatus.php
@@ -11,6 +11,7 @@ final class ChargeStatus extends AbstractValueObject
     const CANCELED = 'canceled';
     const PROCESSING = 'processing';
     const FAILED = 'failed';
+    const CHARGEDBACK = 'chargedback';
 
     const UNDERPAID = 'underpaid';
     const OVERPAID = 'overpaid';
@@ -44,6 +45,10 @@ final class ChargeStatus extends AbstractValueObject
     static public function canceled()
     {
         return new self(self::CANCELED);
+    }
+    static public function chargedback()
+    {
+        return new self(self::CHARGEDBACK);
     }
 
     static public function underpaid()

--- a/src/Kernel/ValueObjects/ChargeStatus.php
+++ b/src/Kernel/ValueObjects/ChargeStatus.php
@@ -17,7 +17,7 @@ final class ChargeStatus extends AbstractValueObject
 
     /**
      *
-     * @var string 
+     * @var string
      */
     private $status;
 
@@ -106,7 +106,7 @@ final class ChargeStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->status;
     }

--- a/src/Kernel/ValueObjects/Configuration/AddressAttributes.php
+++ b/src/Kernel/ValueObjects/Configuration/AddressAttributes.php
@@ -83,13 +83,14 @@ final class AddressAttributes extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/AddressAttributes.php
+++ b/src/Kernel/ValueObjects/Configuration/AddressAttributes.php
@@ -89,7 +89,7 @@ final class AddressAttributes extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/CardConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/CardConfig.php
@@ -261,14 +261,15 @@ final class CardConfig extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/CardConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/CardConfig.php
@@ -11,7 +11,7 @@ final class CardConfig extends AbstractValueObject
 {
     /**
      *
-     * @var bool 
+     * @var bool
      */
     private $enabled;
     /**
@@ -21,28 +21,28 @@ final class CardConfig extends AbstractValueObject
     private $brand;
     /**
      *
-     * @var int 
+     * @var int
      */
     private $maxInstallment;
     /**
      *
-     * @var int 
+     * @var int
      */
     private $maxInstallmentWithoutInterest;
     /**
      *
-     * @var float 
+     * @var float
      */
     private $initialInterest;
     /**
      *
-     * @var float 
+     * @var float
      */
     private $incrementalInterest;
 
     /**
      *
-     * @var int 
+     * @var int
      */
     private $minValue;
 
@@ -268,7 +268,7 @@ final class CardConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/DebitConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/DebitConfig.php
@@ -177,7 +177,7 @@ class DebitConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Configuration/DebitConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/DebitConfig.php
@@ -171,13 +171,14 @@ class DebitConfig extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Configuration/PixConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/PixConfig.php
@@ -134,13 +134,14 @@ class PixConfig extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Configuration/PixConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/PixConfig.php
@@ -140,7 +140,7 @@ class PixConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Configuration/RecurrenceConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/RecurrenceConfig.php
@@ -178,7 +178,7 @@ class RecurrenceConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/RecurrenceConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/RecurrenceConfig.php
@@ -172,13 +172,14 @@ class RecurrenceConfig extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/Configuration/VoucherConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/VoucherConfig.php
@@ -192,13 +192,14 @@ class VoucherConfig extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Configuration/VoucherConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/VoucherConfig.php
@@ -198,7 +198,7 @@ class VoucherConfig extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "enabled" => $this->enabled,

--- a/src/Kernel/ValueObjects/Installment.php
+++ b/src/Kernel/ValueObjects/Installment.php
@@ -161,14 +161,15 @@ final class Installment extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass;
 

--- a/src/Kernel/ValueObjects/Installment.php
+++ b/src/Kernel/ValueObjects/Installment.php
@@ -168,7 +168,7 @@ final class Installment extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass;
 

--- a/src/Kernel/ValueObjects/InvoiceState.php
+++ b/src/Kernel/ValueObjects/InvoiceState.php
@@ -75,7 +75,7 @@ final class InvoiceState extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getState();
     }

--- a/src/Kernel/ValueObjects/InvoiceState.php
+++ b/src/Kernel/ValueObjects/InvoiceState.php
@@ -68,14 +68,15 @@ final class InvoiceState extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->getState();
     }

--- a/src/Kernel/ValueObjects/OrderState.php
+++ b/src/Kernel/ValueObjects/OrderState.php
@@ -104,14 +104,15 @@ final class OrderState extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->getState();
     }

--- a/src/Kernel/ValueObjects/OrderState.php
+++ b/src/Kernel/ValueObjects/OrderState.php
@@ -17,7 +17,7 @@ final class OrderState extends AbstractValueObject
 
     /**
      *
-     * @var string 
+     * @var string
      */
     private $state;
 
@@ -111,7 +111,7 @@ final class OrderState extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getState();
     }

--- a/src/Kernel/ValueObjects/OrderStatus.php
+++ b/src/Kernel/ValueObjects/OrderStatus.php
@@ -91,14 +91,15 @@ final class OrderStatus extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->getStatus();
     }

--- a/src/Kernel/ValueObjects/OrderStatus.php
+++ b/src/Kernel/ValueObjects/OrderStatus.php
@@ -14,7 +14,7 @@ final class OrderStatus extends AbstractValueObject
 
     /**
      *
-     * @var string 
+     * @var string
      */
     private $status;
 
@@ -98,7 +98,7 @@ final class OrderStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getStatus();
     }

--- a/src/Kernel/ValueObjects/PaymentMethod.php
+++ b/src/Kernel/ValueObjects/PaymentMethod.php
@@ -92,7 +92,7 @@ final class PaymentMethod extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->paymentMethod;
     }

--- a/src/Kernel/ValueObjects/PaymentMethod.php
+++ b/src/Kernel/ValueObjects/PaymentMethod.php
@@ -85,14 +85,15 @@ final class PaymentMethod extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->paymentMethod;
     }

--- a/src/Kernel/ValueObjects/TransactionStatus.php
+++ b/src/Kernel/ValueObjects/TransactionStatus.php
@@ -184,7 +184,7 @@ final class TransactionStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->status;
     }

--- a/src/Kernel/ValueObjects/TransactionStatus.php
+++ b/src/Kernel/ValueObjects/TransactionStatus.php
@@ -183,14 +183,15 @@ final class TransactionStatus extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->status;
     }

--- a/src/Kernel/ValueObjects/TransactionStatus.php
+++ b/src/Kernel/ValueObjects/TransactionStatus.php
@@ -114,10 +114,12 @@ final class TransactionStatus extends AbstractValueObject
     {
         return new self(self::FAILED);
     }
+
     public static function chargedback()
     {
         return new self(self::CHARGEDBACK);
     }
+    
     public static function waitingPayment()
     {
         return new self(self::WAITING_PAYMENT);

--- a/src/Kernel/ValueObjects/TransactionStatus.php
+++ b/src/Kernel/ValueObjects/TransactionStatus.php
@@ -15,6 +15,7 @@ final class TransactionStatus extends AbstractValueObject
     const WITH_ERROR = 'withError';
     const NOT_AUTHORIZED = 'notAuthorized';
     const FAILED = 'failed';
+    const CHARGEDBACK = 'chargedback';
 
     const GENERATED = 'generated';
     const UNDERPAID = 'underpaid';
@@ -113,7 +114,10 @@ final class TransactionStatus extends AbstractValueObject
     {
         return new self(self::FAILED);
     }
-
+    public static function chargedback()
+    {
+        return new self(self::CHARGEDBACK);
+    }
     public static function waitingPayment()
     {
         return new self(self::WAITING_PAYMENT);

--- a/src/Kernel/ValueObjects/TransactionType.php
+++ b/src/Kernel/ValueObjects/TransactionType.php
@@ -85,14 +85,15 @@ final class TransactionType extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->type;
     }

--- a/src/Kernel/ValueObjects/TransactionType.php
+++ b/src/Kernel/ValueObjects/TransactionType.php
@@ -13,7 +13,7 @@ final class TransactionType extends AbstractValueObject
     const PIX = 'pix';
     /**
      *
-     * @var string 
+     * @var string
      */
     private $type;
 
@@ -92,7 +92,7 @@ final class TransactionType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->type;
     }

--- a/src/Kernel/ValueObjects/VersionInfo.php
+++ b/src/Kernel/ValueObjects/VersionInfo.php
@@ -102,14 +102,15 @@ final class VersionInfo extends AbstractValueObject
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     *
-     * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since  5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      *
+      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since  5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Kernel/ValueObjects/VersionInfo.php
+++ b/src/Kernel/ValueObjects/VersionInfo.php
@@ -8,12 +8,12 @@ final class VersionInfo extends AbstractValueObject
 {
     /**
      *
-     * @var string 
+     * @var string
      */
     private $moduleVersion;
     /**
      *
-     * @var string 
+     * @var string
      */
     private $coreVersion;
 
@@ -109,7 +109,7 @@ final class VersionInfo extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Address.php
+++ b/src/Payment/Aggregates/Address.php
@@ -340,7 +340,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 
@@ -354,7 +354,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
         $obj->country = $this->country;
         $obj->line1 = $this->getLine1();
         $obj->line2 = $this->getLine2();
-        
+
         return $obj;
     }
 

--- a/src/Payment/Aggregates/Address.php
+++ b/src/Payment/Aggregates/Address.php
@@ -334,13 +334,14 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return string data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return string data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -176,7 +176,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -171,13 +171,14 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -47,7 +47,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setCode($code)
     {
-        $this->code = substr($code, 0, 52);
+        $this->code = substr($code ?? "", 0, 52);
     }
 
     /**
@@ -64,7 +64,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setName($name)
     {
-        $this->name = substr($name, 0, 64);
+        $this->name = substr($name ?? "", 0, 64);
     }
 
     /**
@@ -83,7 +83,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
     public function setEmail($email)
     {
         $email = trim($email);
-        $email = substr($email, 0, 64);
+        $email = substr($email ?? "", 0, 64);
 
         $this->validateEmail($email);
         $this->email = $email;
@@ -125,6 +125,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
         $this->document = $this->formatDocument($document);
 
         if (empty($this->document) && empty($this->getPagarmeId())) {
+
             $inputName = $this->i18n->getDashboard('document');
             $message = $this->i18n->getDashboard(
                 "The %s should not be empty!",
@@ -227,11 +228,8 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
         $customerRequest->code = $this->getCode();
         $customerRequest->name = $this->getName();
         $customerRequest->email = $this->getEmail();
-        if ($this->getDocument()) {
-            $customerRequest->document = $this->getDocument();
-            $customerRequest->type = $this->getTypeValue();
-        }
-
+        $customerRequest->document = $this->getDocument();
+        $customerRequest->type = $this->getTypeValue();
         $customerRequest->address = $this->getAddressToSDK();
         $customerRequest->phones = $this->getPhonesToSDK();
 
@@ -263,7 +261,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
     {
         $document = preg_replace(
             '/[^0-9]/is', '',
-            substr($document, 0, 16)
+            substr($document ?? "", 0, 16)
         );
 
         return $document;

--- a/src/Payment/Aggregates/Item.php
+++ b/src/Payment/Aggregates/Item.php
@@ -113,13 +113,14 @@ final class Item extends AbstractEntity implements ConvertibleToSDKRequestsInter
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Item.php
+++ b/src/Payment/Aggregates/Item.php
@@ -119,7 +119,7 @@ final class Item extends AbstractEntity implements ConvertibleToSDKRequestsInter
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Order.php
+++ b/src/Payment/Aggregates/Order.php
@@ -276,13 +276,14 @@ final class Order extends AbstractEntity implements ConvertibleToSDKRequestsInte
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Order.php
+++ b/src/Payment/Aggregates/Order.php
@@ -282,7 +282,7 @@ final class Order extends AbstractEntity implements ConvertibleToSDKRequestsInte
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Payments/AbstractCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractCreditCardPayment.php
@@ -180,7 +180,8 @@ abstract class AbstractCreditCardPayment extends AbstractPayment
         $this->brand = $brand;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj =  parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/AbstractCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractCreditCardPayment.php
@@ -180,7 +180,7 @@ abstract class AbstractCreditCardPayment extends AbstractPayment
         $this->brand = $brand;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj =  parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/AbstractPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractPayment.php
@@ -18,7 +18,7 @@ abstract class AbstractPayment
     use WithCustomerTrait;
     use WithOrderTrait;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Payments/AbstractPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractPayment.php
@@ -18,7 +18,8 @@ abstract class AbstractPayment
     use WithCustomerTrait;
     use WithOrderTrait;
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Payments/BoletoPayment.php
+++ b/src/Payment/Aggregates/Payments/BoletoPayment.php
@@ -49,7 +49,7 @@ final class BoletoPayment extends AbstractPayment
         $this->instructions = $instructions;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/BoletoPayment.php
+++ b/src/Payment/Aggregates/Payments/BoletoPayment.php
@@ -49,7 +49,8 @@ final class BoletoPayment extends AbstractPayment
         $this->instructions = $instructions;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/NewCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/NewCreditCardPayment.php
@@ -49,7 +49,7 @@ class NewCreditCardPayment extends AbstractCreditCardPayment
         $this->saveOnSuccess = boolval($saveOnSuccess);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/NewCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/NewCreditCardPayment.php
@@ -49,7 +49,8 @@ class NewCreditCardPayment extends AbstractCreditCardPayment
         $this->saveOnSuccess = boolval($saveOnSuccess);
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/NewVoucherPayment.php
+++ b/src/Payment/Aggregates/Payments/NewVoucherPayment.php
@@ -52,7 +52,8 @@ final class NewVoucherPayment extends AbstractCreditCardPayment
         $this->saveOnSuccess = boolval($saveOnSuccess);
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/NewVoucherPayment.php
+++ b/src/Payment/Aggregates/Payments/NewVoucherPayment.php
@@ -52,7 +52,7 @@ final class NewVoucherPayment extends AbstractCreditCardPayment
         $this->saveOnSuccess = boolval($saveOnSuccess);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/PixPayment.php
+++ b/src/Payment/Aggregates/Payments/PixPayment.php
@@ -72,7 +72,7 @@ final class PixPayment extends AbstractPayment
         $this->additionalInformation = $additionalInformation;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = parent::jsonSerialize();
         $obj->expiresIn = $this->getExpiresIn();

--- a/src/Payment/Aggregates/Payments/PixPayment.php
+++ b/src/Payment/Aggregates/Payments/PixPayment.php
@@ -72,7 +72,8 @@ final class PixPayment extends AbstractPayment
         $this->additionalInformation = $additionalInformation;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = parent::jsonSerialize();
         $obj->expiresIn = $this->getExpiresIn();

--- a/src/Payment/Aggregates/Payments/SavedCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedCreditCardPayment.php
@@ -30,7 +30,8 @@ final class SavedCreditCardPayment extends AbstractCreditCardPayment
         $this->owner = $owner;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/SavedCreditCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedCreditCardPayment.php
@@ -30,7 +30,7 @@ final class SavedCreditCardPayment extends AbstractCreditCardPayment
         $this->owner = $owner;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/SavedDebitCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedDebitCardPayment.php
@@ -30,7 +30,8 @@ final class SavedDebitCardPayment extends AbstractCreditCardPayment
         $this->owner = $owner;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/SavedDebitCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedDebitCardPayment.php
@@ -30,7 +30,7 @@ final class SavedDebitCardPayment extends AbstractCreditCardPayment
         $this->owner = $owner;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/SavedVoucherCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedVoucherCardPayment.php
@@ -42,7 +42,8 @@ final class SavedVoucherCardPayment extends AbstractCreditCardPayment
         return $this->cvv;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/Payments/SavedVoucherCardPayment.php
+++ b/src/Payment/Aggregates/Payments/SavedVoucherCardPayment.php
@@ -42,7 +42,7 @@ final class SavedVoucherCardPayment extends AbstractCreditCardPayment
         return $this->cvv;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = parent::jsonSerialize();
 

--- a/src/Payment/Aggregates/SavedCard.php
+++ b/src/Payment/Aggregates/SavedCard.php
@@ -145,13 +145,14 @@ final class SavedCard extends AbstractEntity
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/SavedCard.php
+++ b/src/Payment/Aggregates/SavedCard.php
@@ -151,7 +151,7 @@ final class SavedCard extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Shipping.php
+++ b/src/Payment/Aggregates/Shipping.php
@@ -92,7 +92,7 @@ final class Shipping extends AbstractEntity implements ConvertibleToSDKRequestsI
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/Aggregates/Shipping.php
+++ b/src/Payment/Aggregates/Shipping.php
@@ -86,13 +86,14 @@ final class Shipping extends AbstractEntity implements ConvertibleToSDKRequestsI
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+      * Specify data which should be serialized to JSON
+      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+      * @return mixed data which can be serialized by <b>json_encode</b>,
+      * which is a value of any type other than a resource.
+      * @since 5.4.0
+    */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/BoletoBank.php
+++ b/src/Payment/ValueObjects/BoletoBank.php
@@ -109,7 +109,7 @@ class BoletoBank extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/BoletoBank.php
+++ b/src/Payment/ValueObjects/BoletoBank.php
@@ -109,7 +109,8 @@ class BoletoBank extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
        $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/CustomerPhones.php
+++ b/src/Payment/ValueObjects/CustomerPhones.php
@@ -82,7 +82,8 @@ final class CustomerPhones extends AbstractValueObject implements ConvertibleToS
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/CustomerPhones.php
+++ b/src/Payment/ValueObjects/CustomerPhones.php
@@ -82,7 +82,7 @@ final class CustomerPhones extends AbstractValueObject implements ConvertibleToS
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/CustomerType.php
+++ b/src/Payment/ValueObjects/CustomerType.php
@@ -54,7 +54,7 @@ class CustomerType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->type;
     }

--- a/src/Payment/ValueObjects/CustomerType.php
+++ b/src/Payment/ValueObjects/CustomerType.php
@@ -54,7 +54,8 @@ class CustomerType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->type;
     }

--- a/src/Payment/ValueObjects/Discounts.php
+++ b/src/Payment/ValueObjects/Discounts.php
@@ -90,10 +90,8 @@ class Discounts extends AbstractValueObject
         return get_object_vars($this) === (array)$object;
     }
 
-    /**
-     * @return array|mixed
-     */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return get_object_vars($this);
     }

--- a/src/Payment/ValueObjects/Discounts.php
+++ b/src/Payment/ValueObjects/Discounts.php
@@ -93,7 +93,7 @@ class Discounts extends AbstractValueObject
     /**
      * @return array|mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Payment/ValueObjects/PaymentMethod.php
+++ b/src/Payment/ValueObjects/PaymentMethod.php
@@ -98,7 +98,8 @@ final class PaymentMethod extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->getMethod();
     }

--- a/src/Payment/ValueObjects/PaymentMethod.php
+++ b/src/Payment/ValueObjects/PaymentMethod.php
@@ -98,7 +98,7 @@ final class PaymentMethod extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getMethod();
     }

--- a/src/Payment/ValueObjects/Phone.php
+++ b/src/Payment/ValueObjects/Phone.php
@@ -86,7 +86,7 @@ final class Phone extends AbstractValueObject implements ConvertibleToSDKRequest
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/Phone.php
+++ b/src/Payment/ValueObjects/Phone.php
@@ -86,7 +86,8 @@ final class Phone extends AbstractValueObject implements ConvertibleToSDKRequest
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/PixBank.php
+++ b/src/Payment/ValueObjects/PixBank.php
@@ -109,7 +109,8 @@ class PixBank extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
        $obj = new \stdClass();
 

--- a/src/Payment/ValueObjects/PixBank.php
+++ b/src/Payment/ValueObjects/PixBank.php
@@ -109,7 +109,7 @@ class PixBank extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/Charge.php
+++ b/src/Recurrence/Aggregates/Charge.php
@@ -165,6 +165,11 @@ final class Charge extends AbstractEntity implements ChargeInterface
         $this->status = ChargeStatus::canceled();
     }
 
+    public function chargedback()
+    {
+        $this->status = ChargeStatus::canceled();
+    }
+
     /**
      *
      * @return int

--- a/src/Recurrence/Aggregates/Charge.php
+++ b/src/Recurrence/Aggregates/Charge.php
@@ -554,7 +554,8 @@ final class Charge extends AbstractEntity implements ChargeInterface
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new stdClass();
 

--- a/src/Recurrence/Aggregates/Charge.php
+++ b/src/Recurrence/Aggregates/Charge.php
@@ -549,7 +549,7 @@ final class Charge extends AbstractEntity implements ChargeInterface
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new stdClass();
 

--- a/src/Recurrence/Aggregates/Charge.php
+++ b/src/Recurrence/Aggregates/Charge.php
@@ -167,7 +167,7 @@ final class Charge extends AbstractEntity implements ChargeInterface
 
     public function chargedback()
     {
-        $this->status = ChargeStatus::canceled();
+        $this->status = ChargeStatus::chargedback();
     }
 
     /**

--- a/src/Recurrence/Aggregates/Cycle.php
+++ b/src/Recurrence/Aggregates/Cycle.php
@@ -94,7 +94,8 @@ class Cycle extends AbstractEntity
         return $this->cycleEnd;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return get_object_vars($this);
     }

--- a/src/Recurrence/Aggregates/Cycle.php
+++ b/src/Recurrence/Aggregates/Cycle.php
@@ -94,7 +94,7 @@ class Cycle extends AbstractEntity
         return $this->cycleEnd;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Recurrence/Aggregates/Increment.php
+++ b/src/Recurrence/Aggregates/Increment.php
@@ -66,7 +66,8 @@ class Increment extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/Increment.php
+++ b/src/Recurrence/Aggregates/Increment.php
@@ -66,7 +66,7 @@ class Increment extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/Invoice.php
+++ b/src/Recurrence/Aggregates/Invoice.php
@@ -238,7 +238,7 @@ class Invoice extends AbstractEntity
         return null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'subscriptionId' => $this->getSubscriptionId()

--- a/src/Recurrence/Aggregates/Invoice.php
+++ b/src/Recurrence/Aggregates/Invoice.php
@@ -238,7 +238,8 @@ class Invoice extends AbstractEntity
         return null;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             'subscriptionId' => $this->getSubscriptionId()

--- a/src/Recurrence/Aggregates/Plan.php
+++ b/src/Recurrence/Aggregates/Plan.php
@@ -390,7 +390,7 @@ final class Plan extends AbstractEntity implements RecurrenceEntityInterface, Pr
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/Plan.php
+++ b/src/Recurrence/Aggregates/Plan.php
@@ -390,7 +390,8 @@ final class Plan extends AbstractEntity implements RecurrenceEntityInterface, Pr
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/ProductSubscription.php
+++ b/src/Recurrence/Aggregates/ProductSubscription.php
@@ -226,7 +226,7 @@ class ProductSubscription extends AbstractEntity implements ProductSubscriptionI
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/ProductSubscription.php
+++ b/src/Recurrence/Aggregates/ProductSubscription.php
@@ -226,7 +226,8 @@ class ProductSubscription extends AbstractEntity implements ProductSubscriptionI
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/Aggregates/Repetition.php
+++ b/src/Recurrence/Aggregates/Repetition.php
@@ -156,7 +156,7 @@ class Repetition extends AbstractEntity implements RepetitionInterface
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'id' => $this->getId(),

--- a/src/Recurrence/Aggregates/Repetition.php
+++ b/src/Recurrence/Aggregates/Repetition.php
@@ -156,7 +156,8 @@ class Repetition extends AbstractEntity implements RepetitionInterface
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             'id' => $this->getId(),

--- a/src/Recurrence/Aggregates/SubProduct.php
+++ b/src/Recurrence/Aggregates/SubProduct.php
@@ -234,7 +234,7 @@ class SubProduct extends AbstractEntity implements SubProductEntityInterface
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/Aggregates/SubProduct.php
+++ b/src/Recurrence/Aggregates/SubProduct.php
@@ -234,7 +234,8 @@ class SubProduct extends AbstractEntity implements SubProductEntityInterface
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -447,6 +447,7 @@ class Subscription extends AbstractEntity
 
         return $this;
     }
+
     public function updateCharge(ChargeInterface $updatedCharge, $overwriteId = false)
     {
         $charges = $this->getCharges();
@@ -467,7 +468,11 @@ class Subscription extends AbstractEntity
     }
 
 
-
+    /**
+     * Undocumented function
+     *
+     * @return void
+     */
     public function applyOrderStatusFromCharges()
     {
         if (empty($this->getCharges())) {
@@ -503,7 +508,6 @@ class Subscription extends AbstractEntity
         ) {
             $this->setStatus(SubscriptionStatus::canceled());
         }
-        $data = $listChargeStatus;
         if (
             in_array(ChargeStatus::chargedback()->getStatus(), $listChargeStatus)
         ) {
@@ -518,6 +522,7 @@ class Subscription extends AbstractEntity
             $this->setStatus(SubscriptionStatus::$currentStatus());
         }
     }
+    
     /**
      * @param ChargeInterface[] $charges
      */

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -19,6 +19,7 @@ use Pagarme\Core\Recurrence\ValueObjects\PlanId;
 use Pagarme\Core\Recurrence\ValueObjects\IntervalValueObject;
 use Pagarme\Core\Recurrence\Aggregates\SubProduct;
 use Pagarme\Core\Recurrence\Aggregates\Invoice;
+use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
 
 class Subscription extends AbstractEntity
 {
@@ -446,7 +447,77 @@ class Subscription extends AbstractEntity
 
         return $this;
     }
+    public function updateCharge(ChargeInterface $updatedCharge, $overwriteId = false)
+    {
+        $charges = $this->getCharges();
 
+        foreach ($charges as &$charge) {
+            if ($charge->getPagarmeId()->equals($updatedCharge->getPagarmeId())) {
+                $chargeId = $charge->getId();
+                $charge = $updatedCharge;
+                if ($overwriteId) {
+                    $charge->setId($chargeId);
+                }
+                $this->charges = $charges;
+                return;
+            }
+        }
+
+        $this->addCharge($updatedCharge);
+    }
+
+
+
+    public function applyOrderStatusFromCharges()
+    {
+        if (empty($this->getCharges())) {
+            return;
+        }
+
+        $listChargeStatus = [];
+        foreach ($this->getCharges() as $charge) {
+            $listChargeStatus[$charge->getStatus()->getStatus()] =
+                $charge->getStatus()->getStatus();
+        }
+
+        $chargesStatusEquals = count($listChargeStatus) == 1;
+
+        if (
+            $chargesStatusEquals &&
+            $this->getCharges()[0]->getStatus()->equals(ChargeStatus::overpaid())
+        ) {
+            $this->setStatus(SubscriptionStatus::paid());
+            return;
+        }
+
+        if (
+            in_array(ChargeStatus::paid()->getStatus(), $listChargeStatus) &&
+            in_array(ChargeStatus::overpaid()->getStatus(), $listChargeStatus)
+        ) {
+            $this->setStatus(SubscriptionStatus::paid());
+        }
+
+        if (
+            in_array(ChargeStatus::failed()->getStatus(), $listChargeStatus) &&
+            in_array(ChargeStatus::canceled()->getStatus(), $listChargeStatus)
+        ) {
+            $this->setStatus(SubscriptionStatus::canceled());
+        }
+        $data = $listChargeStatus;
+        if (
+            in_array(ChargeStatus::chargedback()->getStatus(), $listChargeStatus)
+        ) {
+            $this->setStatus(SubscriptionStatus::canceled());
+        }
+
+        if (
+            $chargesStatusEquals &&
+            !$this->getCharges()[0]->getStatus()->equals(ChargeStatus::underpaid())
+        ) {
+            $currentStatus = reset($listChargeStatus);
+            $this->setStatus(SubscriptionStatus::$currentStatus());
+        }
+    }
     /**
      * @param ChargeInterface[] $charges
      */

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -588,7 +588,7 @@ class Subscription extends AbstractEntity
         return null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -658,7 +658,8 @@ class Subscription extends AbstractEntity
         return null;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/Aggregates/Subscription.php
+++ b/src/Recurrence/Aggregates/Subscription.php
@@ -467,12 +467,6 @@ class Subscription extends AbstractEntity
         $this->addCharge($updatedCharge);
     }
 
-
-    /**
-     * Undocumented function
-     *
-     * @return void
-     */
     public function applyOrderStatusFromCharges()
     {
         if (empty($this->getCharges())) {

--- a/src/Recurrence/Aggregates/SubscriptionItem.php
+++ b/src/Recurrence/Aggregates/SubscriptionItem.php
@@ -99,7 +99,7 @@ class SubscriptionItem extends AbstractEntity
         $this->updatedAt = $updatedAt;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/Aggregates/SubscriptionItem.php
+++ b/src/Recurrence/Aggregates/SubscriptionItem.php
@@ -99,7 +99,8 @@ class SubscriptionItem extends AbstractEntity
         $this->updatedAt = $updatedAt;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             "id" => $this->getId(),

--- a/src/Recurrence/Services/InvoiceService.php
+++ b/src/Recurrence/Services/InvoiceService.php
@@ -6,6 +6,7 @@ use Pagarme\Core\Kernel\Services\APIService;
 use Pagarme\Core\Kernel\Services\LogService;
 use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
 use Pagarme\Core\Payment\Services\ResponseHandlers\ErrorExceptionHandler;
+use Pagarme\Core\Recurrence\Aggregates\Charge;
 use Pagarme\Core\Recurrence\Aggregates\Invoice;
 use Pagarme\Core\Recurrence\Factories\ChargeFactory;
 use Pagarme\Core\Recurrence\Factories\InvoiceFactory;
@@ -117,6 +118,12 @@ class InvoiceService
         );
 
         return $apiService->cancelInvoice($invoice);
+    }
+
+    public function setChargedbackStatus(Charge $charge)
+    {
+        $charge->setMetadata(json_decode($charge->getMetadata()));
+        $this->getChargeRepository()->save($charge);
     }
 
     public function getApiService()

--- a/src/Recurrence/ValueObjects/IntervalValueObject.php
+++ b/src/Recurrence/ValueObjects/IntervalValueObject.php
@@ -117,7 +117,8 @@ class IntervalValueObject extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             'intervalType' => $this->getIntervalType(),

--- a/src/Recurrence/ValueObjects/IntervalValueObject.php
+++ b/src/Recurrence/ValueObjects/IntervalValueObject.php
@@ -117,7 +117,7 @@ class IntervalValueObject extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'intervalType' => $this->getIntervalType(),

--- a/src/Recurrence/ValueObjects/InvoiceStatus.php
+++ b/src/Recurrence/ValueObjects/InvoiceStatus.php
@@ -80,7 +80,8 @@ final class InvoiceStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->getStatus();
     }

--- a/src/Recurrence/ValueObjects/InvoiceStatus.php
+++ b/src/Recurrence/ValueObjects/InvoiceStatus.php
@@ -11,7 +11,7 @@ final class InvoiceStatus extends AbstractValueObject
     const PENDING = 'pending';
 
     /**
-     * @var string 
+     * @var string
      */
     private $status;
 
@@ -80,7 +80,7 @@ final class InvoiceStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getStatus();
     }

--- a/src/Recurrence/ValueObjects/PricingSchemeValueObject.php
+++ b/src/Recurrence/ValueObjects/PricingSchemeValueObject.php
@@ -92,7 +92,8 @@ class PricingSchemeValueObject extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/ValueObjects/PricingSchemeValueObject.php
+++ b/src/Recurrence/ValueObjects/PricingSchemeValueObject.php
@@ -92,7 +92,7 @@ class PricingSchemeValueObject extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Recurrence/ValueObjects/SubscriptionStatus.php
+++ b/src/Recurrence/ValueObjects/SubscriptionStatus.php
@@ -92,7 +92,8 @@ final class SubscriptionStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->getStatus();
     }

--- a/src/Recurrence/ValueObjects/SubscriptionStatus.php
+++ b/src/Recurrence/ValueObjects/SubscriptionStatus.php
@@ -10,6 +10,7 @@ final class SubscriptionStatus extends AbstractValueObject
     const CANCELED = 'canceled';
     const FUTURE = 'future';
     const FAILED = 'failed';
+    const CHARGEDBACK = 'chargedback';
 
     /**
      * @var string
@@ -44,6 +45,10 @@ final class SubscriptionStatus extends AbstractValueObject
     public static function failed()
     {
         return new self(self::FAILED);
+    }
+    public static function chargedback()
+    {
+        return new self(self::CHARGEDBACK);
     }
 
     /**

--- a/src/Recurrence/ValueObjects/SubscriptionStatus.php
+++ b/src/Recurrence/ValueObjects/SubscriptionStatus.php
@@ -46,6 +46,7 @@ final class SubscriptionStatus extends AbstractValueObject
     {
         return new self(self::FAILED);
     }
+    
     public static function chargedback()
     {
         return new self(self::CHARGEDBACK);

--- a/src/Recurrence/ValueObjects/SubscriptionStatus.php
+++ b/src/Recurrence/ValueObjects/SubscriptionStatus.php
@@ -12,7 +12,7 @@ final class SubscriptionStatus extends AbstractValueObject
     const FAILED = 'failed';
 
     /**
-     * @var string 
+     * @var string
      */
     private $status;
 
@@ -86,7 +86,7 @@ final class SubscriptionStatus extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getStatus();
     }

--- a/src/Webhook/Aggregates/Webhook.php
+++ b/src/Webhook/Aggregates/Webhook.php
@@ -87,7 +87,8 @@ class Webhook extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         // TODO: Implement jsonSerialize() method.
     }

--- a/src/Webhook/Aggregates/Webhook.php
+++ b/src/Webhook/Aggregates/Webhook.php
@@ -9,13 +9,13 @@ class Webhook extends AbstractEntity
 {
     /**
      *
-     * @var WebhookType 
+     * @var WebhookType
      */
     protected $type;
 
     /**
      *
-     * @var AbstractEntity 
+     * @var AbstractEntity
      */
     protected $entity;
 
@@ -87,7 +87,7 @@ class Webhook extends AbstractEntity
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         // TODO: Implement jsonSerialize() method.
     }

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -265,6 +265,10 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         return $result;
     }
 
+    /**
+     * @param Webhook $webhook
+     * @return array
+     */
     protected function handleChargedback(Webhook $webhook)
     {
         

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -308,8 +308,8 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         
         $history = $i18n->getDashboard('Subscription canceled');
         $order->getPlatformOrder()->addHistoryComment($history);
-        
-        $subscriptionRepository->save($this->order);
+
+        $subscriptionRepository->save($order);
         
         return [
             "message" => 'Subscription cancel registered',

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -16,9 +16,11 @@ use Pagarme\Core\Kernel\Services\OrderService;
 use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
 use Pagarme\Core\Kernel\ValueObjects\Id\SubscriptionId;
 use Pagarme\Core\Kernel\ValueObjects\OrderStatus;
+use Pagarme\Core\Kernel\ValueObjects\TransactionStatus;
 use Pagarme\Core\Recurrence\Repositories\ChargeRepository;
 use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
 use Pagarme\Core\Webhook\Aggregates\Webhook;
+use Pagarme\Core\Recurrence\ValueObjects\SubscriptionStatus;
 
 final class ChargeRecurrenceService extends AbstractHandlerService
 {
@@ -261,6 +263,56 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         ];
 
         return $result;
+    }
+
+    protected function handleChargedback(Webhook $webhook)
+    {
+        
+        $order = $this->order;
+        
+        $subscriptionRepository = new SubscriptionRepository();
+        $i18n = new LocalizationService();
+
+        /**
+         * @var Charge $charge
+         */
+        $charge = $webhook->getEntity();
+
+        $transaction = $charge->getLastTransaction();
+        
+        $outdatedCharge = $this->chargeRepository->findByPagarmeId(
+            $charge->getPagarmeId()
+        );
+
+        if ($outdatedCharge !== null) {
+            $charge = $outdatedCharge;
+        }
+         /**
+         * @var Charge $outdatedCharge
+         */
+        if ($transaction !== null) {
+            $outdatedCharge->addTransaction($transaction);
+        }
+
+        $charge->chargedback();
+        $order->updateCharge($charge);
+        $order->applyOrderStatusFromCharges();
+
+
+        $this->order->setStatus(SubscriptionStatus::canceled());
+
+        $subscriptionRepository->save($this->order);
+
+        $history = $i18n->getDashboard('Subscription canceled');
+        $this->order->getPlatformOrder()->addHistoryComment($history);
+
+        $this->orderService->syncPlatformWith($order, false);
+        
+        return [
+            "message" => 'Subscription cancel registered',
+            "code" => 200
+        ];
+
     }
 
     //@todo handleProcessing

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -19,8 +19,8 @@ use Pagarme\Core\Kernel\ValueObjects\OrderStatus;
 use Pagarme\Core\Kernel\ValueObjects\TransactionStatus;
 use Pagarme\Core\Recurrence\Repositories\ChargeRepository;
 use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
+use Pagarme\Core\Recurrence\Services\InvoiceService;
 use Pagarme\Core\Webhook\Aggregates\Webhook;
-use Pagarme\Core\Recurrence\ValueObjects\SubscriptionStatus;
 
 final class ChargeRecurrenceService extends AbstractHandlerService
 {
@@ -273,7 +273,7 @@ final class ChargeRecurrenceService extends AbstractHandlerService
     {
         
         $order = $this->order;
-        
+        $invoiceService = new InvoiceService();
         $subscriptionRepository = new SubscriptionRepository();
         $i18n = new LocalizationService();
 
@@ -298,19 +298,18 @@ final class ChargeRecurrenceService extends AbstractHandlerService
             $outdatedCharge->addTransaction($transaction);
         }
 
-        $charge->chargedback();
+        
+        $charge->cancel();
         $order->updateCharge($charge);
         $order->applyOrderStatusFromCharges();
-
-
-        $this->order->setStatus(SubscriptionStatus::canceled());
-
-        $subscriptionRepository->save($this->order);
-
+        
+        $charge->chargedback();
+        $invoiceService->setChargedbackStatus($charge);
+        
         $history = $i18n->getDashboard('Subscription canceled');
-        $this->order->getPlatformOrder()->addHistoryComment($history);
-
-        $this->orderService->syncPlatformWith($order, false);
+        $order->getPlatformOrder()->addHistoryComment($history);
+        
+        $subscriptionRepository->save($this->order);
         
         return [
             "message" => 'Subscription cancel registered',

--- a/src/Webhook/ValueObjects/WebhookType.php
+++ b/src/Webhook/ValueObjects/WebhookType.php
@@ -8,12 +8,12 @@ final class WebhookType extends AbstractValueObject
 {
     /**
      *
-     * @var string 
+     * @var string
      */
     private $entityType;
     /**
      *
-     * @var string 
+     * @var string
      */
     private $action;
 
@@ -92,7 +92,7 @@ final class WebhookType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $obj = new \stdClass();
 

--- a/src/Webhook/ValueObjects/WebhookType.php
+++ b/src/Webhook/ValueObjects/WebhookType.php
@@ -92,7 +92,8 @@ final class WebhookType extends AbstractValueObject
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $obj = new \stdClass();
 

--- a/tests/Abstractions/AbstractRepositoryTest.php
+++ b/tests/Abstractions/AbstractRepositoryTest.php
@@ -11,7 +11,7 @@ abstract class AbstractRepositoryTest extends AbstractSetupTest
      */
     protected $repo;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->repo = $this->getRepository();

--- a/tests/Abstractions/AbstractSetupTest.php
+++ b/tests/Abstractions/AbstractSetupTest.php
@@ -8,13 +8,13 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractSetupTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         PlatformCoreSetup::bootstrap();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $migrate = new Migrate(PlatformCoreSetup::getDatabaseAccessObject());

--- a/tests/Hub/Aggregates/InstallTokenTests.php
+++ b/tests/Hub/Aggregates/InstallTokenTests.php
@@ -21,7 +21,7 @@ class InstallTokenTests extends TestCase
     /**
      * @throws InvalidParamException
      */
-    public function setUp()
+    public function setUp(): void
     {
         $token = hash('sha512', '1' . '|' . microtime());
         $this->hubInstallToken = new HubInstallToken($token);
@@ -50,32 +50,32 @@ class InstallTokenTests extends TestCase
 
     public function testInstallTokenMethodIsUsed()
     {
-        $this->assertInternalType('bool', $this->installToken->isUsed());
+        $this->assertIsBool($this->installToken->isUsed());
     }
 
     public function testInstallTokenIsExpired()
     {
-        $this->assertInternalType('bool', $this->installToken->isExpired());
+        $this->assertIsBool($this->installToken->isExpired());
     }
 
     public function testInstallTokenGetCreatedAtTimestamp()
     {
-        $this->assertInternalType('int', $this->installToken->getCreatedAtTimestamp());
+        $this->assertIsInt($this->installToken->getCreatedAtTimestamp());
     }
 
     public function testInstallTokenGetExpireAtTimestamp()
     {
-        $this->assertInternalType('int', $this->installToken->getExpireAtTimestamp());
+        $this->assertIsInt($this->installToken->getExpireAtTimestamp());
     }
 
     public function testInstallTokenIsDisabled()
     {
-        $this->assertInternalType('bool', $this->installToken->isDisabled());
+        $this->assertIsBool($this->installToken->isDisabled());
     }
 
     public function testInstallTokenJsonSerialize()
     {
-        $this->assertInternalType('object', $this->installToken->jsonSerialize());
+        $this->assertIsObject($this->installToken->jsonSerialize());
         $this->assertInstanceOf(\stdClass::class, $this->installToken->jsonSerialize());
     }
 }

--- a/tests/Hub/Factories/HubCommandFactoryTest.php
+++ b/tests/Hub/Factories/HubCommandFactoryTest.php
@@ -14,7 +14,7 @@ class HubCommandFactoryTest extends TestCase
     private $factory;
     private $payload;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new HubCommandFactory();
 

--- a/tests/Kernel/Aggregates/ChargeTests.php
+++ b/tests/Kernel/Aggregates/ChargeTests.php
@@ -9,7 +9,6 @@ use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
 use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
 use Pagarme\Core\Kernel\ValueObjects\Id\TransactionId;
 use PHPUnit\Framework\TestCase;
-use Mockery;
 use Carbon\Carbon;
 
 class ChargeTests extends TestCase
@@ -23,7 +22,7 @@ class ChargeTests extends TestCase
     public function testExpectedAnObjectOrderidToSetOrderId()
     {
         $charge = new Charge();
-        $orderId = Mockery::mock(OrderId::class);
+        $orderId = $this->createMock(OrderId::class);
         $charge->setOrderId($orderId);
 
         $this->assertEquals($orderId, $charge->getOrderId());

--- a/tests/Kernel/Aggregates/ConfigurationTests.php
+++ b/tests/Kernel/Aggregates/ConfigurationTests.php
@@ -12,7 +12,7 @@ class ConfigurationTests extends TestCase
      */
     private $configuration;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->configuration = new Configuration();
     }
@@ -20,34 +20,34 @@ class ConfigurationTests extends TestCase
     public function testIsEnabled()
     {
         $this->configuration->setEnabled(true);
-        $this->assertInternalType('bool', $this->configuration->isEnabled());
+        $this->assertIsBool($this->configuration->isEnabled());
         $this->assertEquals(true, $this->configuration->isEnabled());
     }
 
     public function testIsUnabled()
     {
         $this->configuration->setEnabled(false);
-        $this->assertInternalType('bool', $this->configuration->isEnabled());
+        $this->assertIsBool($this->configuration->isEnabled());
         $this->assertEquals(false, $this->configuration->isEnabled());
     }
 
     public function testHubEnvironmentStartsNull()
     {
-        $this->assertInternalType('null', $this->configuration->getHubEnvironment());
+        $this->assertNull($this->configuration->getHubEnvironment());
         $this->assertEquals('', $this->configuration->getHubEnvironment());
     }
 
     public function testHubEnvironmentIsSandbox()
     {
         $this->configuration->setHubEnvironment('Sandbox');
-        $this->assertInternalType('string', $this->configuration->getHubEnvironment());
+        $this->assertIsString($this->configuration->getHubEnvironment());
         $this->assertEquals('Sandbox', $this->configuration->getHubEnvironment());
     }
 
     public function testHubEnvironmentIsProduction()
     {
         $this->configuration->setHubEnvironment('Production');
-        $this->assertInternalType('string', $this->configuration->getHubEnvironment());
+        $this->assertIsString($this->configuration->getHubEnvironment());
         $this->assertEquals('Production', $this->configuration->getHubEnvironment());
     }
 }

--- a/tests/Kernel/Aggregates/LogObjectTests.php
+++ b/tests/Kernel/Aggregates/LogObjectTests.php
@@ -12,14 +12,14 @@ class LogObjectTests extends TestCase
      */
     private $logObject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->logObject = new LogObject();
     }
 
     public function testJsonSerialize()
     {
-        $this->assertInternalType('object', $this->logObject->jsonSerialize());
+        $this->assertIsObject($this->logObject->jsonSerialize());
         $this->assertInstanceOf(\stdClass::class, $this->logObject->jsonSerialize());
     }
 }

--- a/tests/Kernel/Factories/Configurations/PixConfigFactoryTest.php
+++ b/tests/Kernel/Factories/Configurations/PixConfigFactoryTest.php
@@ -5,8 +5,6 @@ namespace Pagarme\Core\Test\Kernel\Aggregates\Factories\Configurations;
 
 use Pagarme\Core\Kernel\Factories\Configurations\PixConfigFactory;
 use PHPUnit\Framework\TestCase;
-use Mockery;
-use Carbon\Carbon;
 
 class PixConfigFactoryTest extends TestCase
 {
@@ -19,7 +17,7 @@ class PixConfigFactoryTest extends TestCase
      */
     private $pixConfigFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->dataWithAdditionalInformation = (object) array(
             'enabled' => true,

--- a/tests/Kernel/I18N/PTBRTests.php
+++ b/tests/Kernel/I18N/PTBRTests.php
@@ -12,7 +12,7 @@ class PTBRTests extends TestCase
      */
     private $ptbr;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->ptbr = new PTBR();
     }

--- a/tests/Kernel/Response/ServiceResponseTest.php
+++ b/tests/Kernel/Response/ServiceResponseTest.php
@@ -2,16 +2,8 @@
 
 namespace Pagarme\Core\Test\Kernel\Aggregates;
 
-use Pagarme\Core\Kernel\Aggregates\Charge;
-use Pagarme\Core\Kernel\Aggregates\Transaction;
-use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\Responses\ServiceResponse;
-use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
-use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
-use Pagarme\Core\Kernel\ValueObjects\Id\TransactionId;
 use PHPUnit\Framework\TestCase;
-use Mockery;
-use Carbon\Carbon;
 
 class ServiceResponseTest extends TestCase
 {
@@ -19,7 +11,7 @@ class ServiceResponseTest extends TestCase
     {
         $object = new ServiceResponse(true, 'Foi um sucesso', (object)['status' => 200, 'message' => 'ok']);
         $this->assertEquals('Foi um sucesso', $object->getMessage());
-        $this->assertInternalType('object', $object->getObject());
+        $this->assertIsObject($object->getObject());
         $this->assertInstanceOf(\stdClass::class, $object->getObject());
         $this->assertEquals(true, $object->isSuccess());
     }

--- a/tests/Kernel/Services/MoneyServiceTests.php
+++ b/tests/Kernel/Services/MoneyServiceTests.php
@@ -13,7 +13,7 @@ class MoneyServiceTests extends TestCase
      */
     private $moneyService;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->moneyService = new MoneyService();
     }

--- a/tests/Kernel/ValueObjects/TransactionStatusTest.php
+++ b/tests/Kernel/ValueObjects/TransactionStatusTest.php
@@ -44,6 +44,10 @@ class TransactionStatusTest extends TestCase
             'method' => 'failed',
             'value' => 'failed'
         ],
+        'CHARGEDBACK' => [
+            'method' => 'chargedback',
+            'value' => 'chargedback'
+        ],
         'GENERATED' => [
             'method' => 'generated',
             'value' => 'generated'

--- a/tests/Maintenance/Services/InstallDataSource/CoreInstallDataSourceTests.php
+++ b/tests/Maintenance/Services/InstallDataSource/CoreInstallDataSourceTests.php
@@ -12,14 +12,14 @@ class CoreInstallDataSourceTests extends TestCase
      */
     private $coreInstallDataSource;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->coreInstallDataSource = new CoreInstallDataSource();
     }
 
     public function testGetIntegrityFilePath()
     {
-        $this->assertContains(
+        $this->assertStringEndsWith(
             DIRECTORY_SEPARATOR . 'Assets' . DIRECTORY_SEPARATOR . 'integrityData',
             $this->coreInstallDataSource->getIntegrityFilePath()
         );

--- a/tests/Payment/Aggregates/AddressTests.php
+++ b/tests/Payment/Aggregates/AddressTests.php
@@ -12,7 +12,7 @@ class AddressTests extends TestCase
      */
     private $address;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->address = new Address();
     }

--- a/tests/Payment/Aggregates/CustomerTests.php
+++ b/tests/Payment/Aggregates/CustomerTests.php
@@ -16,7 +16,7 @@ class CustomerTests extends TestCase
      */
     private $customer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->customer = new Customer();
     }

--- a/tests/Recurrence/Aggregates/ChargeTest.php
+++ b/tests/Recurrence/Aggregates/ChargeTest.php
@@ -3,7 +3,6 @@
 namespace Pagarme\Core\Test\Recurrence\Aggregates;
 
 use Carbon\Carbon;
-use Mockery;
 use Pagarme\Core\Kernel\Aggregates\Transaction;
 use Pagarme\Core\Kernel\ValueObjects\ChargeStatus;
 use Pagarme\Core\Kernel\ValueObjects\Id\ChargeId;
@@ -26,7 +25,7 @@ class ChargeTest extends TestCase
      */
     private $charge;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->charge = new Charge();
     }
@@ -34,8 +33,8 @@ class ChargeTest extends TestCase
     public function testChargeObject()
     {
         $this->charge->setId(1);
-        $this->charge->setPagarmeId(Mockery::mock(ChargeId::class));
-        $this->charge->setOrderId(Mockery::mock(OrderId::class));
+        $this->charge->setPagarmeId($this->createMock(ChargeId::class));
+        $this->charge->setOrderId($this->createMock(OrderId::class));
         $this->charge->setAmount(100);
         $this->charge->setPaidAmount(100);
         $this->charge->setCanceledAmount(0);
@@ -47,10 +46,10 @@ class ChargeTest extends TestCase
         $this->charge->setSubscriptionId(new SubscriptionId('sub_1234567890123457'));
 
         $customer = new Customer();
-        $customer->setPagarmeId(Mockery::mock(CustomerId::class));
+        $customer->setPagarmeId($this->createMock(CustomerId::class));
 
         $invoice = new Invoice();
-        $invoice->setPagarmeId(Mockery::mock(InvoiceId::class));
+        $invoice->setPagarmeId($this->createMock(InvoiceId::class));
 
         $this->charge->setCustomer($customer);
         $this->charge->setInvoice($invoice);
@@ -95,7 +94,7 @@ class ChargeTest extends TestCase
     public function testExpectedAnObjectOrderidToSetOrderId()
     {
         $charge = new Charge();
-        $orderId = Mockery::mock(OrderId::class);
+        $orderId = $this->createMock(OrderId::class);
         $charge->setOrderId($orderId);
 
         $this->assertEquals($orderId, $charge->getOrderId());
@@ -115,6 +114,7 @@ class ChargeTest extends TestCase
      */
     public function testShouldThrowAnExceptionIfAmountIsInvalid()
     {
+        $this->expectException(\Pagarme\Core\Kernel\Exceptions\InvalidParamException::class);
         $charge = new Charge();
         $charge->setAmount(-10);
     }
@@ -125,6 +125,7 @@ class ChargeTest extends TestCase
      */
     public function testShouldThrowAnExceptionIfAmountIsNotNumeric()
     {
+        $this->expectException(\Pagarme\Core\Kernel\Exceptions\InvalidParamException::class);
         $charge = new Charge();
         $charge->setAmount("string");
     }
@@ -148,6 +149,7 @@ class ChargeTest extends TestCase
      */
     public function testShouldThrowAnExceptionIfPaidAmountIsNotNumeric()
     {
+        $this->expectException(\Pagarme\Core\Kernel\Exceptions\InvalidParamException::class);
         $charge = new Charge();
         $charge->setPaidAmount("string");
     }
@@ -179,6 +181,7 @@ class ChargeTest extends TestCase
      */
     public function testShouldThrowAnExceptionIfCanceledAmountIsNotNumeric()
     {
+        $this->expectException(\Pagarme\Core\Kernel\Exceptions\InvalidParamException::class);
         $charge = new Charge();
         $charge->setCanceledAmount("string");
     }
@@ -219,6 +222,7 @@ class ChargeTest extends TestCase
      */
     public function testShouldThrowAnExceptionIfRefoundedAmountIsNotNumeric()
     {
+        $this->expectException(\Pagarme\Core\Kernel\Exceptions\InvalidParamException::class);
         $charge = new Charge();
         $charge->setRefundedAmount("string");
     }

--- a/tests/Recurrence/Aggregates/CycleTest.php
+++ b/tests/Recurrence/Aggregates/CycleTest.php
@@ -13,7 +13,7 @@ class CycleTest extends TestCase
      */
     private $cycle;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cycle = new Cycle();
     }

--- a/tests/Recurrence/Aggregates/IncrementTest.php
+++ b/tests/Recurrence/Aggregates/IncrementTest.php
@@ -14,7 +14,7 @@ class IncrementTest extends TestCase
      */
     private $increment;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->increment = new Increment();
     }

--- a/tests/Recurrence/Aggregates/InvoiceTest.php
+++ b/tests/Recurrence/Aggregates/InvoiceTest.php
@@ -17,7 +17,7 @@ class InvoiceTest extends TestCase
      */
     private $invoice;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->invoice = new Invoice();
     }

--- a/tests/Recurrence/Aggregates/PlanTest.php
+++ b/tests/Recurrence/Aggregates/PlanTest.php
@@ -14,7 +14,7 @@ class PlanTest extends TestCase
 {
     private $plan;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->plan = new Plan();
     }
@@ -83,10 +83,10 @@ class PlanTest extends TestCase
         $this->assertEquals($this->plan->getAllowInstallments(), $allowInstallments);
 
         $this->plan->setCreatedAt($createdAt);
-        $this->assertInternalType('string', $this->plan->getCreatedAt());
+        $this->assertIsString($this->plan->getCreatedAt());
 
         $this->plan->setUpdatedAt($updatedAt);
-        $this->assertInternalType('string', $this->plan->getUpdatedAt());
+        $this->assertIsString($this->plan->getUpdatedAt());
 
         $this->plan->setIntervalType($intervalType);
         $this->assertEquals($this->plan->getIntervalType(), $intervalType);
@@ -101,6 +101,7 @@ class PlanTest extends TestCase
      */
     public function testShouldNotAddAnEmptyProductId()
     {
+        $this->expectException(\Exception::class);
         $this->plan->setProductId("");
     }
 
@@ -116,6 +117,7 @@ class PlanTest extends TestCase
      */
     public function testShouldNotAddAnEmptyBillingType()
     {
+        $this->expectException(\Exception::class);
         $this->plan->setBillingType("");
     }
 
@@ -131,6 +133,7 @@ class PlanTest extends TestCase
      */
     public function testShouldNotAddAnEmptyStatus()
     {
+        $this->expectException(\Exception::class);
         $this->plan->setStatus("");
     }
 
@@ -146,6 +149,7 @@ class PlanTest extends TestCase
      */
     public function testShouldNotAddAnNotIntegerTrialPeriodDays()
     {
+        $this->expectException(\Exception::class);
         $this->plan->setTrialPeriodDays("");
     }
 
@@ -256,6 +260,8 @@ class PlanTest extends TestCase
      */
     public function testShouldReturnAnExceptionIfTrySetAnInvalidIntervalType()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Interval not find");
         $this->plan->setIntervalType("wrong interval Type");
     }
 
@@ -265,6 +271,8 @@ class PlanTest extends TestCase
      */
     public function testShouldReturnAnExceptionIfTrySetAnInvalidIntervalCount()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Interval count not compatible");
         $this->plan->setIntervalCount("wrong interval count");
     }
 }

--- a/tests/Recurrence/Aggregates/ProductSubscriptionTest.php
+++ b/tests/Recurrence/Aggregates/ProductSubscriptionTest.php
@@ -10,7 +10,7 @@ class ProductSubscriptionTest extends TestCase
 {
     private $productSubscription;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->productSubscription = new ProductSubscription();
     }
@@ -21,6 +21,8 @@ class ProductSubscriptionTest extends TestCase
      */
     public function testShouldNotAddAnEmptyProductId()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Product id should not be empty! Passed value:");
         $this->productSubscription->setProductId("");
     }
 
@@ -36,6 +38,8 @@ class ProductSubscriptionTest extends TestCase
      */
     public function testShouldNotAddAnEmptyBillingType()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Billing type should not be empty! Passed value:");
         $this->productSubscription->setBillingType("");
     }
 
@@ -53,11 +57,13 @@ class ProductSubscriptionTest extends TestCase
     }
 
     /**
+     * TODO: refactor ProductSubscription to return InvalidParamException
      * @requires PHP >= 7.0
-     * @expectedException \Error
+     * @expectedException \TypeError
      */
     public function testShouldThrowAnTypeErrorExceptionIfAddAnWrongTypeOfRepetition()
     {
+        $this->expectError(\TypeError::class);
         $this->productSubscription->addRepetition("WrongType");
     }
 

--- a/tests/Recurrence/Aggregates/RepetitionTest.php
+++ b/tests/Recurrence/Aggregates/RepetitionTest.php
@@ -11,17 +11,20 @@ class RepetitionTest extends TestCase
 {
     private $repetition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repetition = new Repetition();
     }
 
     /**
+     * TODO: Change exception type to InvalidArgumentException
      * @expectedException \Exception
      * @expectedExceptionMessage  Recurrence price should be greater than 0: -10!
      */
     public function testShouldNotAddANegativePrice()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Recurrence price should be greater than 0: -10!");
         $this->repetition->setRecurrencePrice(-10);
     }
 
@@ -37,6 +40,8 @@ class RepetitionTest extends TestCase
      */
     public function testShouldNotSetAnWrongIntervalType()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Interval is not available! Passed value: hour");
         $this->repetition->setInterval("hour");
     }
 
@@ -143,6 +148,8 @@ class RepetitionTest extends TestCase
      */
     public function testShouldNotAddANegativeCycle()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Cycles should be greater than or equal to 0: -10!");
         $this->repetition->setCycles(-10);
     }
 

--- a/tests/Recurrence/Aggregates/SubProductTest.php
+++ b/tests/Recurrence/Aggregates/SubProductTest.php
@@ -12,7 +12,7 @@ class SubProductTest extends TestCase
 {
     private $subProduct;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->subProduct = new SubProduct();
     }
@@ -67,10 +67,10 @@ class SubProductTest extends TestCase
         $this->assertEquals($this->subProduct->getRecurrenceType(), $recurrenceType);
 
         $this->subProduct->setCreatedAt($createdAt);
-        $this->assertInternalType('string', $this->subProduct->getCreatedAt());
+        $this->assertIsString($this->subProduct->getCreatedAt());
 
         $this->subProduct->setUpdatedAt($updatedAt);
-        $this->assertInternalType('string', $this->subProduct->getUpdatedAt());
+        $this->assertIsString($this->subProduct->getUpdatedAt());
 
         $this->subProduct->setSelectedRepetition($selectedRepetition);
         $this->assertInstanceOf(Repetition::class, $this->subProduct->getSelectedRepetition());

--- a/tests/Recurrence/Aggregates/SubscriptionTest.php
+++ b/tests/Recurrence/Aggregates/SubscriptionTest.php
@@ -2,8 +2,6 @@
 
 namespace Pagarme\Core\Test\Recurrence\Aggregates;
 
-use Mockery;
-use PagarmeCoreApiLib\Models\CreateAddressRequest;
 use PagarmeCoreApiLib\Models\CreateCardRequest;
 use PagarmeCoreApiLib\Models\CreateSubscriptionRequest;
 use Pagarme\Core\Kernel\Interfaces\PlatformOrderInterface;
@@ -31,7 +29,7 @@ class SubscriptionTest extends TestCase
      */
     private $subscription;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->subscription = new Subscription();
         parent::setUp();
@@ -51,12 +49,12 @@ class SubscriptionTest extends TestCase
         $this->subscription->setDescription("Description");
         $this->subscription->setStatus(SubscriptionStatus::active());
         $this->subscription->setPaymentMethod(PaymentMethod::credit_card());
-        $this->subscription->setPagarmeId(Mockery::mock(SubscriptionId::class));
-        $this->subscription->setSubscriptionId(Mockery::mock(SubscriptionId::class));
-        $this->subscription->setPlatformOrder(Mockery::mock(PlatformOrderInterface::class));
-        $this->subscription->setInvoice(Mockery::mock(Invoice::class));
+        $this->subscription->setPagarmeId($this->createMock(SubscriptionId::class));
+        $this->subscription->setSubscriptionId($this->createMock(SubscriptionId::class));
+        $this->subscription->setPlatformOrder($this->createMock(PlatformOrderInterface::class));
+        $this->subscription->setInvoice($this->createMock(Invoice::class));
         $this->subscription->setCurrentCharge(new Charge());
-        $this->subscription->setPlanId(Mockery::mock(PlanId::class));
+        $this->subscription->setPlanId($this->createMock(PlanId::class));
         $this->subscription->setCustomer(new Customer());
         $this->subscription->setItems([new SubProduct]);
         $this->subscription->setShipping(new Shipping);

--- a/tests/Recurrence/Repositories/ProductSubscriptionRepositoryTest.php
+++ b/tests/Recurrence/Repositories/ProductSubscriptionRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Pagarme\Core\Test\Recurrence\Repositories;
 
-use Mockery;
 use Pagarme\Core\Kernel\ValueObjects\AbstractValidString;
 use Pagarme\Core\Recurrence\Aggregates\ProductSubscription;
 use Pagarme\Core\Recurrence\Aggregates\Repetition;
@@ -113,7 +112,7 @@ class ProductSubscriptionRepositoryTest extends AbstractRepositoryTest
 
     public function testShouldReturnAProductSubscriptionSearchByPagarmeId()
     {
-        $mockAbstractString = Mockery::mock(AbstractValidString::class);
+        $mockAbstractString = $this->createMock(AbstractValidString::class);
         $this->assertNull($this->repo->findByPagarmeId($mockAbstractString), "Method not implemented");
     }
 

--- a/tests/Recurrence/Repositories/RepetitionRepositoryTest.php
+++ b/tests/Recurrence/Repositories/RepetitionRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Pagarme\Core\Test\Recurrence\Repositories;
 
-use Mockery;
 use Pagarme\Core\Kernel\ValueObjects\AbstractValidString;
 use Pagarme\Core\Recurrence\Aggregates\Repetition;
 use Pagarme\Core\Recurrence\Factories\RepetitionFactory;
@@ -98,7 +97,7 @@ class RepetitionRepositoryTest extends AbstractRepositoryTest
 
     public function testShouldReturnARepetitionSearchByPagarmeId()
     {
-        $mockAbstractString = Mockery::mock(AbstractValidString::class);
+        $mockAbstractString = $this->createMock(AbstractValidString::class);
         $this->assertNull($this->repo->findByPagarmeId($mockAbstractString), "Method not implemented");
     }
 

--- a/tests/Recurrence/Services/CartRules/MoreThanOneRecurrenceProductTest.php
+++ b/tests/Recurrence/Services/CartRules/MoreThanOneRecurrenceProductTest.php
@@ -91,22 +91,20 @@ class MoreThanOneRecurrenceProductTest extends TestCase
 
     protected function getRecurrenceConfig($allow = true, $error = "")
     {
-        $recurrenceConfigMock = \Mockery::mock(RecurrenceConfig::class);
-
-        $recurrenceConfigMock
-            ->shouldReceive('getConflictMessageRecurrenceProductWithRecurrenceProduct')
-            ->andReturn($error);
+        $recurrenceConfigMock = $this->getMockBuilder(RecurrenceConfig::class)->getMock();
+        $recurrenceConfigMock->method('getConflictMessageRecurrenceProductWithRecurrenceProduct')
+            ->willReturn($error);
 
         if ($allow) {
             $recurrenceConfigMock
-                ->shouldReceive('isPurchaseRecurrenceProductWithRecurrenceProduct')
-                ->andReturnTrue();
+                ->method('isPurchaseRecurrenceProductWithRecurrenceProduct')
+                ->willReturn(true);
 
             return $recurrenceConfigMock;
         }
         $recurrenceConfigMock
-            ->shouldReceive('isPurchaseRecurrenceProductWithRecurrenceProduct')
-            ->andReturnFalse();
+            ->method('isPurchaseRecurrenceProductWithRecurrenceProduct')
+            ->willReturn(false);
 
         return $recurrenceConfigMock;
     }

--- a/tests/Recurrence/Services/InvoiceServiceTest.php
+++ b/tests/Recurrence/Services/InvoiceServiceTest.php
@@ -18,7 +18,7 @@ class InvoiceServiceTest extends AbstractSetupTest
      */
     protected $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->service = \Mockery::mock(InvoiceService::class)->makePartial();
 

--- a/tests/Recurrence/Services/ProductSubscriptionServiceTest.php
+++ b/tests/Recurrence/Services/ProductSubscriptionServiceTest.php
@@ -15,7 +15,7 @@ class ProductSubscriptionServiceTest extends AbstractSetupTest
      */
     protected $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $logMock = \Mockery::mock(LogService::class);
         $logMock->shouldReceive('info')->andReturnTrue();
@@ -76,6 +76,8 @@ class ProductSubscriptionServiceTest extends AbstractSetupTest
      */
     public function testShouldThrowAnExceptionBecauseTheRecurrenceProductIdNotExists()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Subscription Product not found - ID : 23");
         $this->service->delete(23);
     }
 
@@ -115,6 +117,8 @@ class ProductSubscriptionServiceTest extends AbstractSetupTest
      */
     public function testShouldNotAllowSaveProductSubscriptionWithProductIdAlreadyExisting()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Product already exists on recurrence product- Product ID : 23");
         $product = [
             "product_id" => "23",
             "boleto" => true,

--- a/tests/Recurrence/Services/RecurrenceServiceTest.php
+++ b/tests/Recurrence/Services/RecurrenceServiceTest.php
@@ -16,7 +16,7 @@ class RecurrenceServiceTest extends AbstractSetupTest
      */
     protected $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $logMock = \Mockery::mock(LogService::class);
         $logMock->shouldReceive('info')->andReturnTrue();

--- a/tests/Recurrence/ValueObjects/IntervalValueObjectTest.php
+++ b/tests/Recurrence/ValueObjects/IntervalValueObjectTest.php
@@ -13,6 +13,8 @@ class IntervalValueObjectTest extends TestCase
      */
     public function testShouldReturnAExceptionBecauseTheTypeNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Call to undefined method Pagarme\Core\Recurrence\ValueObjects\IntervalValueObject::hour()");
         IntervalValueObject::hour(2);
     }
 
@@ -22,6 +24,8 @@ class IntervalValueObjectTest extends TestCase
      */
     public function testShouldReturnAExceptionBecauseTheValueIsWrong()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Interval count should be greater than 0: -10!");
         IntervalValueObject::month(-10);
     }
 

--- a/tests/Recurrence/ValueObjects/PricingSchemeValueObjectTest.php
+++ b/tests/Recurrence/ValueObjects/PricingSchemeValueObjectTest.php
@@ -13,6 +13,8 @@ class PricingSchemeValueObjectTest extends TestCase
      */
     public function testShouldReturnAExceptionBecauseTheTypeNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Call to undefined method Pagarme\Core\Recurrence\ValueObjects\PricingSchemeValueObject::time()");
         PricingSchemeValueObject::time(2);
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-288
| **What?**         | Adjusting compatibility between php 7 and php 8 and fix tests
| **Why?**          | To unify php7 and php8 deployments and avoid rework
| **How?**          | Adding the #[\ReturnTypeWillChange] attribute and delegating the client update function to the ecommerce module core

About [#[\ReturnTypeWillChange]](https://www.php.net/manual/en/class.returntypewillchange.php)