### PR TITLE
PAOPN-269: assign failed status to invoice

### DIFF
--- a/src/Recurrence/Aggregates/Charge.php
+++ b/src/Recurrence/Aggregates/Charge.php
@@ -170,6 +170,11 @@ final class Charge extends AbstractEntity implements ChargeInterface
         $this->status = ChargeStatus::chargedback();
     }
 
+    public function failed()
+    {
+        $this->status = ChargeStatus::failed();
+    }
+
     /**
      *
      * @return int

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -303,7 +303,7 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         $order->updateCharge($charge);
         $order->applyOrderStatusFromCharges();
         
-        $charge->chargedback();
+        $charge->failed();
         $invoiceService->setChargedbackStatus($charge);
         
         $history = $i18n->getDashboard('Subscription canceled');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-269
| **What?**         | Assigns chargedback status to invoices on recurrence
| **Why?**          | To assign the same status as dash
| **How?**          | When the webhook receives the charge.chagedback
