### PR TITLE
PAOPN-301 Hiding customer info from API

### DIFF
--- a/src/Maintenance/Services/OrderInfoRetrieverService.php
+++ b/src/Maintenance/Services/OrderInfoRetrieverService.php
@@ -43,6 +43,15 @@ class OrderInfoRetrieverService implements InfoRetrieverServiceInterface
         $platformOrderInfo->payments = $platformOrder->getPaymentCollection();
         $platformOrderInfo->invoices = $platformOrder->getInvoiceCollection();
 
+        $regex = '/(?<=\S{2})\S/';
+
+        $platformOrderInfo->order['customer_email'] = preg_replace('/^.{3}\K|.(?=.*@)/','*', $platformOrderInfo->order['customer_email']);
+        $platformOrderInfo->order['customer_firstname'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_firstname']);
+        $platformOrderInfo->order['customer_lastname'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_lastname']);
+        $platformOrderInfo->order['customer_middlename'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_middlename']);
+        $platformOrderInfo->order['customer_taxvat'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_taxvat']);
+        $platformOrderInfo->payments[0]['cc_owner'] = preg_replace($regex, '*', $platformOrderInfo->payments[0]['cc_owner']);
+
         return $platformOrderInfo;
     }
 

--- a/src/Maintenance/Services/OrderInfoRetrieverService.php
+++ b/src/Maintenance/Services/OrderInfoRetrieverService.php
@@ -16,17 +16,41 @@ class OrderInfoRetrieverService implements InfoRetrieverServiceInterface
         $orderInfo->core = $this->getCoreOrderInfo($value);
         $orderInfo->platform = $this->getPlatformOrderInfo($value);
 
+        $this->blurOrderInfo($orderInfo);
+
         return $orderInfo;
     }
 
+    private function blurOrderInfo($orderInfo)
+    {
+        $charges = $orderInfo->core->data->getCharges();
+        foreach ($charges as $charge) {
+            $transactions = $charge->getTransactions();
+
+            foreach ($transactions as $transaction) {
+                if ( !empty( $transaction->getCardData() ) ) {
+                    $ownerName = $transaction->getCardData()
+                        ->getOwnerName();
+                    $transaction->getCardData()
+                        ->setOwnerName( preg_replace('/(?<=\S{2})\S/', '*', $ownerName) );
+                }
+
+                $transaction->getPostData()
+                    ->card_data = null;
+
+                $transaction->getPostData()
+                    ->tran_data = null;
+            }
+        }
+    }
 
     private function getPlatformOrderInfo($orderIncrementId)
     {
         $platformOrderClass = MPSetup::get(MPSetup::CONCRETE_PLATFORM_ORDER_DECORATOR_CLASS);
         /**
          *
- * @var PlatformOrderInterface $platformOrder 
-*/
+         * @var PlatformOrderInterface $platformOrder 
+        */
         $platformOrder = new $platformOrderClass();
         $platformOrder->loadByIncrementId($orderIncrementId);
 
@@ -43,16 +67,21 @@ class OrderInfoRetrieverService implements InfoRetrieverServiceInterface
         $platformOrderInfo->payments = $platformOrder->getPaymentCollection();
         $platformOrderInfo->invoices = $platformOrder->getInvoiceCollection();
 
+        $this->blurPlatformOrderCustomerInfo($platformOrderInfo);
+
+        return $platformOrderInfo;
+    }
+
+    private function blurPlatformOrderCustomerInfo($platformOrderInfo)
+    {
         $regex = '/(?<=\S{2})\S/';
 
-        $platformOrderInfo->order['customer_email'] = preg_replace('/^.{3}\K|.(?=.*@)/','*', $platformOrderInfo->order['customer_email']);
+        $platformOrderInfo->order['customer_email']= preg_replace('/^.{3}\K|.(?=.*@)/','*', $platformOrderInfo->order['customer_email']);
         $platformOrderInfo->order['customer_firstname'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_firstname']);
         $platformOrderInfo->order['customer_lastname'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_lastname']);
         $platformOrderInfo->order['customer_middlename'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_middlename']);
         $platformOrderInfo->order['customer_taxvat'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_taxvat']);
         $platformOrderInfo->payments[0]['cc_owner'] = preg_replace($regex, '*', $platformOrderInfo->payments[0]['cc_owner']);
-
-        return $platformOrderInfo;
     }
 
     private function getCoreOrderInfo($orderIncrementId)
@@ -60,8 +89,8 @@ class OrderInfoRetrieverService implements InfoRetrieverServiceInterface
         $platformOrderClass = MPSetup::get(MPSetup::CONCRETE_PLATFORM_ORDER_DECORATOR_CLASS);
         /**
          *
- * @var PlatformOrderInterface $platformOrder 
-*/
+         * @var PlatformOrderInterface $platformOrder 
+        */
         $platformOrder = new $platformOrderClass();
         $platformOrder->loadByIncrementId($orderIncrementId);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**           | [https://mundipagg.atlassian.net/browse/PAOPN-301](https://mundipagg.atlassian.net/browse/PAOPN-301)
| **What?**         | Hiding customer info from API
| **Why?**          | To hide sensitive information
| **How?**          | Using `preg_replace()` function to replace parts of the information with asterisk characters