### PR TITLE
fix: holdername is null in logger

### DIFF
--- a/src/Kernel/Log/BlurData.php
+++ b/src/Kernel/Log/BlurData.php
@@ -170,7 +170,7 @@ class BlurData
     }
 
     /**
-     * @param string $holderName
+     * @param string|null $holderName
      * @return string
      */
     public function blurHolderName(?string $holderName)

--- a/src/Kernel/Log/BlurData.php
+++ b/src/Kernel/Log/BlurData.php
@@ -170,11 +170,12 @@ class BlurData
     }
 
     /**
-     * @param string|null $holderName
+     * @param string $holderName
      * @return string
      */
     public function blurHolderName(?string $holderName)
     {
+        $holderName = $holderName ?? "";
         return preg_replace('/^.{8}/', '$1**', $holderName);
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-288
| **What?**         | Fix bug caused by null parameter in holdername
| **Why?**          | Because PHP 8 does not accept null in string functions
| **How?**          | If null, it is replaced by an empty string