### PR TITLE
PAOPN-301 Hiding customer info from API

### DIFF
--- a/src/Maintenance/Services/OrderInfoRetrieverService.php
+++ b/src/Maintenance/Services/OrderInfoRetrieverService.php
@@ -32,7 +32,7 @@ class OrderInfoRetrieverService implements InfoRetrieverServiceInterface
                     $ownerName = $transaction->getCardData()
                         ->getOwnerName();
                     $transaction->getCardData()
-                        ->setOwnerName( preg_replace('/(?<=\S{2})\S/', '*', $ownerName) );
+                        ->setOwnerName(preg_replace('/(?<=\S{2})\S/', '*', $ownerName ?? ""));
                 }
 
                 $transaction->getPostData()
@@ -67,21 +67,21 @@ class OrderInfoRetrieverService implements InfoRetrieverServiceInterface
         $platformOrderInfo->payments = $platformOrder->getPaymentCollection();
         $platformOrderInfo->invoices = $platformOrder->getInvoiceCollection();
 
-        $this->blurPlatformOrderCustomerInfo($platformOrderInfo);
+        $this->blurPlatformOrderInfo($platformOrderInfo);
 
         return $platformOrderInfo;
     }
 
-    private function blurPlatformOrderCustomerInfo($platformOrderInfo)
+    private function blurPlatformOrderInfo($platformOrderInfo)
     {
         $regex = '/(?<=\S{2})\S/';
 
-        $platformOrderInfo->order['customer_email']= preg_replace('/^.{3}\K|.(?=.*@)/','*', $platformOrderInfo->order['customer_email']);
-        $platformOrderInfo->order['customer_firstname'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_firstname']);
-        $platformOrderInfo->order['customer_lastname'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_lastname']);
-        $platformOrderInfo->order['customer_middlename'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_middlename']);
-        $platformOrderInfo->order['customer_taxvat'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_taxvat']);
-        $platformOrderInfo->payments[0]['cc_owner'] = preg_replace($regex, '*', $platformOrderInfo->payments[0]['cc_owner']);
+        $platformOrderInfo->order['customer_email'] = preg_replace('/^.{3}\K|.(?=.*@)/','*', $platformOrderInfo->order['customer_email'] ?? "");
+        $platformOrderInfo->order['customer_firstname'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_firstname'] ?? "");
+        $platformOrderInfo->order['customer_lastname'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_lastname'] ?? "");
+        $platformOrderInfo->order['customer_middlename'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_middlename'] ?? "");
+        $platformOrderInfo->order['customer_taxvat'] = preg_replace($regex, '*', $platformOrderInfo->order['customer_taxvat'] ?? "");
+        $platformOrderInfo->payments[0]['cc_owner'] = preg_replace($regex, '*', $platformOrderInfo->payments[0]['cc_owner'] ?? "");
     }
 
     private function getCoreOrderInfo($orderIncrementId)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**           | [https://mundipagg.atlassian.net/browse/PAOPN-301](https://mundipagg.atlassian.net/browse/PAOPN-301)
| **What?**         | Hiding customer info from API
| **Why?**          | To hide sensitive information (with fix to PHP 8)
| **How?**          | Using `preg_replace()` function to replace parts of the information with asterisk characters. If data is null, it's changed to empty string