### PR TITLE
PAOPN-349: add telephone on customer update

### DIFF
--- a/src/Payment/Factories/CustomerFactory.php
+++ b/src/Payment/Factories/CustomerFactory.php
@@ -82,13 +82,13 @@ class CustomerFactory implements FactoryInterface
                 new CustomerId($platformData->getPagarmeId())
             );
         }
-
         $customer->setCode($platformData->getCode());
         $customer->setName($platformData->getName());
         $customer->setEmail($platformData->getEmail());
         $customer->setDocument($platformData->getDocument());
         $customer->setType($platformData->getType());
-        /** @todo set address and phones */
+        $customer->setPhones($platformData->getPhones());
+        /** @todo set address */
 
         return $customer;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-349
| **What?**         | Add telephone on customer update.
| **Why?**          | If the admin updated the customer's registration, the API was updated and removed the customer's phone, generating a problem in the generation of charges in the recurrence
| **How?**          | Add telephone on customer update.
