### PR TITLE
Release Split

### DIFF
--- a/src/Kernel/ValueObjects/Id/RecipientId.php
+++ b/src/Kernel/ValueObjects/Id/RecipientId.php
@@ -8,6 +8,7 @@ class RecipientId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^rp_\w{16}$/', $value) === 1;
+        return (preg_match('/^re_\w{25}$/', $value) 
+            || preg_match('/^rp_\w{16}$/', $value)) === 1;
     }
 }

--- a/src/Marketplace/Aggregates/Recipient.php
+++ b/src/Marketplace/Aggregates/Recipient.php
@@ -2,13 +2,13 @@
 
 namespace Pagarme\Core\Marketplace\Aggregates;
 
-use MundiAPILib\Models\CreateBankAccountRequest;
-use MundiAPILib\Models\CreateRecipientRequest;
-use MundiAPILib\Models\CreateTransferRequest;
-use MundiAPILib\Models\CreateTransferSettingsRequest;
-use MundiAPILib\Models\UpdateRecipientBankAccountRequest;
-use MundiAPILib\Models\UpdateRecipientRequest;
-use MundiAPILib\Models\UpdateTransferSettingsRequest;
+use PagarmeCoreApiLib\Models\CreateBankAccountRequest;
+use PagarmeCoreApiLib\Models\CreateRecipientRequest;
+use PagarmeCoreApiLib\Models\CreateTransferRequest;
+use PagarmeCoreApiLib\Models\CreateTransferSettingsRequest;
+use PagarmeCoreApiLib\Models\UpdateRecipientBankAccountRequest;
+use PagarmeCoreApiLib\Models\UpdateRecipientRequest;
+use PagarmeCoreApiLib\Models\UpdateTransferSettingsRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\Services\LocalizationService;

--- a/src/Marketplace/Aggregates/Split.php
+++ b/src/Marketplace/Aggregates/Split.php
@@ -2,8 +2,8 @@
 
 namespace Pagarme\Core\Marketplace\Aggregates;
 
-use MundiAPILib\Models\CreateSplitOptionsRequest;
-use MundiAPILib\Models\CreateSplitRequest;
+use PagarmeCoreApiLib\Models\CreateSplitOptionsRequest;
+use PagarmeCoreApiLib\Models\CreateSplitRequest;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;

--- a/src/Marketplace/Factories/RecipientFactory.php
+++ b/src/Marketplace/Factories/RecipientFactory.php
@@ -2,7 +2,7 @@
 
 namespace Pagarme\Core\Marketplace\Factories;
 
-use MundiAPILib\Controllers\BaseController;
+use PagarmeCoreApiLib\Controllers\BaseController;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Interfaces\FactoryInterface;
 use Pagarme\Core\Kernel\ValueObjects\Id\RecipientId;

--- a/src/Marketplace/Repositories/RecipientRepository.php
+++ b/src/Marketplace/Repositories/RecipientRepository.php
@@ -2,9 +2,9 @@
 
 namespace Pagarme\Core\Marketplace\Repositories;
 
-use MundiAPILib\APIException;
-use MundiAPILib\Models\GetBankAccountResponse;
-use MundiAPILib\Models\GetTransferSettingsResponse;
+use PagarmeCoreApiLib\APIException;
+use PagarmeCoreApiLib\Models\GetBankAccountResponse;
+use PagarmeCoreApiLib\Models\GetTransferSettingsResponse;
 use Pagarme\Core\Kernel\Abstractions\AbstractDatabaseDecorator;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Abstractions\AbstractRepository;

--- a/src/Marketplace/Services/RecipientService.php
+++ b/src/Marketplace/Services/RecipientService.php
@@ -2,11 +2,12 @@
 
 namespace Pagarme\Core\Marketplace\Services;
 
-use MundiAPILib\APIException;
-use MundiAPILib\Models\UpdateRecipientBankAccountRequest;
-use MundiAPILib\Models\UpdateRecipientRequest;
-use MundiAPILib\Models\UpdateTransferSettingsRequest;
-use MundiAPILib\MundiAPIClient;
+use PagarmeCoreApiLib\APIException;
+use PagarmeCoreApiLib\Models\UpdateRecipientBankAccountRequest;
+use PagarmeCoreApiLib\Models\UpdateRecipientRequest;
+use PagarmeCoreApiLib\Models\UpdateTransferSettingsRequest;
+use PagarmeCoreApiLib\PagarmeCoreApiClient;
+use PagarmeCoreApiLib\Configuration;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\Services\LocalizationService;
@@ -39,9 +40,9 @@ class RecipientService
         }
 
         $password = '';
-        \MundiAPILib\Configuration::$basicAuthPassword = '';
+        Configuration::$basicAuthPassword = '';
 
-        $this->pagarmeApi = new MundiAPIClient($secretKey, $password);
+        $this->pagarmeCoreApi = new PagarmeCoreApiClient($secretKey, $password);
         $this->logService = new LogService('RecipientService', true);
         $this->recipientRepository = new RecipientRepository();
         $this->recipientFactory = new RecipientFactory();
@@ -69,7 +70,7 @@ class RecipientService
     public function createRecipientAtPagarme(Recipient $recipient)
     {
         $createRecipientRequest = $recipient->convertToSdkRequest();
-        $recipientController = $this->pagarmeApi->getRecipients();
+        $recipientController = $this->pagarmeCoreApi->getRecipients();
 
         try {
             $logService = $this->logService;
@@ -104,7 +105,7 @@ class RecipientService
          * @var UpdateRecipientBankAccountRequest $updateBankAccountRequest
          */
         list($updateRecipientRequest, $updateBankAccountRequest, $updateTransferSettingsRequest) = $recipient->convertToSdkRequest(true);
-        $recipientController = $this->pagarmeApi->getRecipients();
+        $recipientController = $this->pagarmeCoreApi->getRecipients();
 
         $recipientPrevious = $this->attachBankAccount($recipient);
 
@@ -209,7 +210,7 @@ class RecipientService
     public function attachBankAccount(Recipient $recipient)
     {
         try {
-            $bankAccount = $this->pagarmeApi->getRecipients()->getRecipient($recipient->getPagarmeId())->defaultBankAccount;
+            $bankAccount = $this->pagarmeCoreApi->getRecipients()->getRecipient($recipient->getPagarmeId())->defaultBankAccount;
         } catch (APIException $e) {
             throw $e;
         }
@@ -219,7 +220,7 @@ class RecipientService
     public function attachTransferSettings(Recipient $recipient)
     {
         try {
-            $transferSettings = $this->pagarmeApi->getRecipients()->getRecipient($recipient->getPagarmeId())->transferSettings;
+            $transferSettings = $this->pagarmeCoreApi->getRecipients()->getRecipient($recipient->getPagarmeId())->transferSettings;
         } catch (APIException $e) {
             throw $e;
         }
@@ -228,7 +229,7 @@ class RecipientService
 
     public function findByPagarmeId($pagarmeId)
     {
-        $recipientController = $this->pagarmeApi->getRecipients();
+        $recipientController = $this->pagarmeCoreApi->getRecipients();
         try {
             $logService = $this->logService;
             return $recipientController->getRecipient($pagarmeId);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-304
| **What?**         | Update mundipagg dependency to paymecoreapi. Update to accept both V5 recipient_id patterns
| **Why?**          | Mundipagg is discontinued and if the recipient_id is not updated, it makes it impossible for the user to create new recipients
| **How?**          |  Update mundipagg dependency to paymecoreapi. Update to accept both V5 recipient_id patterns
#### :package: Attachments
 * In a Mark1 V5 update, it stopped adopting the rp_xxxxxxxxxxxxxxxx pattern and went back to using the re_xxxxxxxxxxxxxxxxxxxxxxxxx pattern
