### PR TITLE
Bugfix/paopn 296

### DIFF
--- a/src/Payment/Services/CardService.php
+++ b/src/Payment/Services/CardService.php
@@ -83,10 +83,8 @@ class CardService
                 ) {
                     $savedCardRepository->save($savedCard);
                     $this->logService->info(
-                        $order->getCode(),
                         "Card '{$savedCard->getPagarmeId()->getValue()}' saved."
                     );
-
                 }
             }
         }


### PR DESCRIPTION
the info method of logService needs to receive parameters: string message, object log.

The string message is in object parameter resulting in error.