### PR TITLE
Fixing deprecated "Passing null to parameter"

### DIFF
--- a/integrityDeploy.php
+++ b/integrityDeploy.php
@@ -15,7 +15,7 @@ $concretePlatformCoreSetupClass = $coreClass;
 
 $moduleCoreSetupReflection = new ReflectionClass($concretePlatformCoreSetupClass);
 $concreteCoreSetupFilename = $moduleCoreSetupReflection->getFileName();
-$concreteDir = explode(DIRECTORY_SEPARATOR, $concreteCoreSetupFilename);
+$concreteDir = explode(DIRECTORY_SEPARATOR, $concreteCoreSetupFilename ?? '');
 array_pop($concreteDir);
 $concreteDir = implode(DIRECTORY_SEPARATOR, $concreteDir);
 

--- a/src/Hub/ValueObjects/HubInstallToken.php
+++ b/src/Hub/ValueObjects/HubInstallToken.php
@@ -8,6 +8,6 @@ final class HubInstallToken extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/\w{64}$/', $value) === 1;
+        return preg_match('/\w{64}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -241,7 +241,7 @@ abstract class AbstractModuleCoreSetup
 
         $moduleCoreSetupReflection = new ReflectionClass($concretePlatformCoreSetupClass);
         $concreteCoreSetupFilename = $moduleCoreSetupReflection->getFileName();
-        $concreteDir = explode(DIRECTORY_SEPARATOR, $concreteCoreSetupFilename);
+        $concreteDir = explode(DIRECTORY_SEPARATOR, $concreteCoreSetupFilename ?? '');
         array_pop($concreteDir);
 
         self::$moduleConcreteDir = implode(DIRECTORY_SEPARATOR, $concreteDir);

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -577,7 +577,7 @@ final class Configuration extends AbstractEntity
         $numbers = '/([^0-9])/i';
         $replace = '';
 
-        $minAmount = preg_replace($numbers, $replace, $antifraudMinAmount);
+        $minAmount = preg_replace($numbers, $replace, $antifraudMinAmount ?? '');
 
         if ($minAmount < 0) {
             throw new InvalidParamException(
@@ -893,7 +893,7 @@ final class Configuration extends AbstractEntity
     {
         $methodSplited = explode(
             "_",
-            preg_replace('/(?<=\\w)(?=[A-Z])/',"_$1", $method)
+            preg_replace('/(?<=\\w)(?=[A-Z])/',"_$1", $method ?? '')
         );
 
         $targetObject = $this;

--- a/src/Kernel/Factories/ChargeFactory.php
+++ b/src/Kernel/Factories/ChargeFactory.php
@@ -126,25 +126,25 @@ class ChargeFactory implements FactoryInterface
         $transactions = [];
         if (isset($dbData['tran_id']) && $dbData['tran_id'] !== null) {
             $tranId = explode(',', $dbData['tran_id']);
-            $tranPagarmeId = explode(',', $dbData['tran_pagarme_id']);
-            $tranChargeId = explode(',', $dbData['tran_charge_id']);
-            $tranAmount = explode(',', $dbData['tran_amount']);
-            $tranPaidAmount = explode(',', $dbData['tran_paid_amount']);
-            $tranType = explode(',', $dbData['tran_type']);
-            $tranStatus = explode(',', $dbData['tran_status']);
-            $tranCreatedAt = explode(',', $dbData['tran_created_at']);
+            $tranPagarmeId = explode(',', $dbData['tran_pagarme_id'] ?? '');
+            $tranChargeId = explode(',', $dbData['tran_charge_id'] ?? '');
+            $tranAmount = explode(',', $dbData['tran_amount'] ?? '');
+            $tranPaidAmount = explode(',', $dbData['tran_paid_amount'] ?? '');
+            $tranType = explode(',', $dbData['tran_type'] ?? '');
+            $tranStatus = explode(',', $dbData['tran_status'] ?? '');
+            $tranCreatedAt = explode(',', $dbData['tran_created_at'] ?? '');
 
-            $tranAcquirerNsu = explode(',', $dbData['tran_acquirer_nsu']);
-            $tranAcquirerTid = explode(',', $dbData['tran_acquirer_tid']);
+            $tranAcquirerNsu = explode(',', $dbData['tran_acquirer_nsu'] ?? '');
+            $tranAcquirerTid = explode(',', $dbData['tran_acquirer_tid'] ?? '');
             $tranAcquirerAuthCode = explode(
                 ',',
-                $dbData['tran_acquirer_auth_code']
-            );
-            $tranAcquirerName = explode(',', $dbData['tran_acquirer_name']);
-            $tranAcquirerMessage = explode(',', $dbData['tran_acquirer_message']);
-            $tranBoletoUrl = explode(',', $dbData['tran_boleto_url']);
-            $tranCardData = explode('---', $dbData['tran_card_data']);
-            $tranData = explode('---', $dbData['tran_data']);
+                $dbData['tran_acquirer_auth_code'] ?? ''
+             );
+            $tranAcquirerName = explode(',', $dbData['tran_acquirer_name'] ?? '');
+            $tranAcquirerMessage = explode(',', $dbData['tran_acquirer_message'] ?? '');
+            $tranBoletoUrl = explode(',', $dbData['tran_boleto_url'] ?? '');
+            $tranCardData = explode('---', $dbData['tran_card_data'] ?? '');
+            $tranData = explode('---', $dbData['tran_data'] ?? '');
 
             foreach ($tranId as $index => $id) {
                 $transaction = [

--- a/src/Kernel/Factories/OrderFactory.php
+++ b/src/Kernel/Factories/OrderFactory.php
@@ -132,7 +132,7 @@ class OrderFactory implements FactoryInterface
 
         $order->setPagarmeId(new OrderId($orderId));
 
-        $baseStatus = explode('_', $platformOrder->getStatus());
+        $baseStatus = explode('_', $platformOrder->getStatus() ?? '');
         $status = $baseStatus[0];
         for ($i = 1; $i < count($baseStatus); $i++) {
             $status .= ucfirst(($baseStatus[$i]));

--- a/src/Kernel/Factories/TransactionFactory.php
+++ b/src/Kernel/Factories/TransactionFactory.php
@@ -20,7 +20,7 @@ class TransactionFactory implements FactoryInterface
 
         $transaction->setPagarmeId(new TransactionId($postData['id']));
 
-        $baseStatus = explode('_', $postData['status']);
+        $baseStatus = explode('_', $postData['status'] ?? '');
         $status = $baseStatus[0];
         for ($i = 1; $i < count($baseStatus); $i++) {
             $status .= ucfirst(($baseStatus[$i]));
@@ -34,7 +34,7 @@ class TransactionFactory implements FactoryInterface
         }
         $transaction->setStatus(TransactionStatus::$status());
 
-        $baseType = explode('_', $postData['transaction_type']);
+        $baseType = explode('_', $postData['transaction_type'] ?? '');
         $type = $baseType[0];
         for ($i = 1; $i < count($baseType); $i++) {
             $type .= ucfirst(($baseType[$i]));
@@ -142,7 +142,7 @@ class TransactionFactory implements FactoryInterface
         $transaction->setAcquirerTid($dbData['acquirer_tid']);
         $transaction->setAcquirerAuthCode($dbData['acquirer_auth_code']);
 
-        $baseStatus = explode('_', $dbData['status']);
+        $baseStatus = explode('_', $dbData['status'] ?? '');
         $status = $baseStatus[0];
         for ($i = 1; $i < count($baseStatus); $i++) {
             $status .= ucfirst(($baseStatus[$i]));
@@ -156,7 +156,7 @@ class TransactionFactory implements FactoryInterface
         }
         $transaction->setStatus(TransactionStatus::$status());
 
-        $baseType = explode('_', $dbData['type']);
+        $baseType = explode('_', $dbData['type'] ?? '');
         $type = $baseType[0];
         for ($i = 1; $i < count($baseType); $i++) {
             $type .= ucfirst(($baseType[$i]));

--- a/src/Kernel/Helper/StringFunctionsHelper.php
+++ b/src/Kernel/Helper/StringFunctionsHelper.php
@@ -132,7 +132,7 @@ class StringFunctionsHelper
         return preg_replace(
             "/[^a-zA-Z ]/",
             '',
-            $str
+            $str ?? ''
         );
     }
 
@@ -143,7 +143,7 @@ class StringFunctionsHelper
         return str_replace(
             "'",
             "`",
-            strip_tags($str)
+            strip_tags($str ?? '')
         );
     }
 
@@ -161,7 +161,7 @@ class StringFunctionsHelper
             preg_replace(
                 $pattern,
                 ' ',
-                $text
+                $text ?? ''
             )
         );
 

--- a/src/Kernel/Log/BlurData.php
+++ b/src/Kernel/Log/BlurData.php
@@ -23,7 +23,7 @@ class BlurData
      */
     public function getBlurMethod(string $method)
     {
-        return 'blur' . str_replace(' ', '', ucwords(str_replace('_', ' ', $method)));
+        return 'blur' . str_replace(' ', '', ucwords(str_replace('_', ' ', $method ?? '')));
     }
 
     /**
@@ -94,7 +94,7 @@ class BlurData
      */
     public function blurDocument(string $document)
     {
-        return preg_replace('/\B[^@.]/', '*', $document);
+        return preg_replace('/\B[^@.]/', '*', $document ?? '');
     }
 
     /**
@@ -176,7 +176,7 @@ class BlurData
     public function blurHolderName(?string $holderName)
     {
         $holderName = $holderName ?? "";
-        return preg_replace('/^.{8}/', '$1**', $holderName);
+        return preg_replace('/^.{8}/', '$1**', $holderName ?? '');
     }
 
     /**

--- a/src/Kernel/Repositories/ConfigurationRepository.php
+++ b/src/Kernel/Repositories/ConfigurationRepository.php
@@ -22,7 +22,7 @@ class ConfigurationRepository extends AbstractRepository
             preg_replace(
                 $this->pattern,
                 ' ',
-                $jsonEncoded
+                $jsonEncoded ?? ''
             )
         );
     }

--- a/src/Kernel/Services/LocalizationService.php
+++ b/src/Kernel/Services/LocalizationService.php
@@ -49,7 +49,7 @@ final class LocalizationService
 
     private function getI18NTableOrDefaultFor($locale)
     {
-        $langClass = str_replace('_', '', $locale);
+        $langClass = str_replace('_', '', $locale ?? '');
         $langClass = strtoupper($langClass);
         $langClass = "Pagarme\\Core\\Kernel\\I18N\\$langClass";
 

--- a/src/Kernel/Services/MoneyService.php
+++ b/src/Kernel/Services/MoneyService.php
@@ -36,7 +36,7 @@ final class MoneyService
         return str_replace(
             ['.', ','],
             "",
-            $amount
+            $amount ?? ''
         );
     }
 }

--- a/src/Kernel/Services/OrderService.php
+++ b/src/Kernel/Services/OrderService.php
@@ -339,7 +339,7 @@ final class OrderService
     private function getResponseHandler($response)
     {
         $responseClass = get_class($response);
-        $responseClass = explode('\\', $responseClass);
+        $responseClass = explode('\\', $responseClass ?? '');
 
         $responseClass =
             'Pagarme\\Core\\Payment\\Services\\ResponseHandlers\\' .

--- a/src/Kernel/ValueObjects/Configuration/CardConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/CardConfig.php
@@ -139,10 +139,7 @@ final class CardConfig extends AbstractValueObject
         new Installment($newMaxInstallmentWithoutInterest, 1, 0);
 
         if ($newMaxInstallmentWithoutInterest > $this->maxInstallment) {
-            throw new InvalidParamException(
-                "'Max installment without interest' must be equal or smaller than 'Max Installments'! ",
-                $maxInstallmentWithoutInterest
-            );
+            $newMaxInstallmentWithoutInterest = $this->maxInstallment;
         }
 
         $this->maxInstallmentWithoutInterest = $newMaxInstallmentWithoutInterest;

--- a/src/Kernel/ValueObjects/Id/AccountId.php
+++ b/src/Kernel/ValueObjects/Id/AccountId.php
@@ -8,6 +8,6 @@ class AccountId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^acc_\w{16}$/', $value) === 1;
+        return preg_match('/^acc_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/ChargeId.php
+++ b/src/Kernel/ValueObjects/Id/ChargeId.php
@@ -8,6 +8,6 @@ class ChargeId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^ch_\w{16}$/', $value) === 1;
+        return preg_match('/^ch_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/CustomerId.php
+++ b/src/Kernel/ValueObjects/Id/CustomerId.php
@@ -8,6 +8,6 @@ class CustomerId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^cus_\w{16}$/', $value) === 1;
+        return preg_match('/^cus_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/CycleId.php
+++ b/src/Kernel/ValueObjects/Id/CycleId.php
@@ -8,6 +8,6 @@ class CycleId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^cycle_\w{16}$/', $value) === 1;
+        return preg_match('/^cycle_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/GUID.php
+++ b/src/Kernel/ValueObjects/Id/GUID.php
@@ -8,6 +8,6 @@ class GUID extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^\w{8}-(\w{4}-){3}\w{12}$/', $value) === 1;
+        return preg_match('/^\w{8}-(\w{4}-){3}\w{12}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/InvoiceId.php
+++ b/src/Kernel/ValueObjects/Id/InvoiceId.php
@@ -8,6 +8,6 @@ class InvoiceId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^in_\w{16}$/', $value) === 1;
+        return preg_match('/^in_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/MerchantId.php
+++ b/src/Kernel/ValueObjects/Id/MerchantId.php
@@ -8,6 +8,6 @@ class MerchantId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^merch_\w{16}$/', $value) === 1;
+        return preg_match('/^merch_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/OrderId.php
+++ b/src/Kernel/ValueObjects/Id/OrderId.php
@@ -18,6 +18,6 @@ class OrderId extends AbstractValidString
 
     protected function validateValue($value)
     {
-        return preg_match('/^or_\w{16}$/', $value) === 1;
+        return preg_match('/^or_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/RecipientId.php
+++ b/src/Kernel/ValueObjects/Id/RecipientId.php
@@ -8,7 +8,7 @@ class RecipientId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return (preg_match('/^re_\w{25}$/', $value) 
-            || preg_match('/^rp_\w{16}$/', $value)) === true;
+        return (preg_match('/^re_\w{25}$/', $value ?? '') 
+            || preg_match('/^rp_\w{16}$/', $value ?? '')) === true;
     }
 }

--- a/src/Kernel/ValueObjects/Id/SubscriptionId.php
+++ b/src/Kernel/ValueObjects/Id/SubscriptionId.php
@@ -8,6 +8,6 @@ class SubscriptionId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^sub_\w{16}$/', $value) === 1;
+        return preg_match('/^sub_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Id/TransactionId.php
+++ b/src/Kernel/ValueObjects/Id/TransactionId.php
@@ -8,6 +8,6 @@ class TransactionId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^tran_\w{16}$/', $value) === 1;
+        return preg_match('/^tran_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Key/HubAccessTokenKey.php
+++ b/src/Kernel/ValueObjects/Key/HubAccessTokenKey.php
@@ -6,6 +6,6 @@ final class HubAccessTokenKey extends AbstractSecretKey
 {
     protected function validateValue($value)
     {
-        return preg_match('/^\w{64}$/', $value) === 1;
+        return preg_match('/^\w{64}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Key/PublicKey.php
+++ b/src/Kernel/ValueObjects/Key/PublicKey.php
@@ -8,7 +8,7 @@ final class PublicKey extends AbstractPublicKey implements SensibleDataInterface
 {
     protected function validateValue($value)
     {
-        return preg_match('/^pk_\w{16}$/', $value) === 1;
+        return preg_match('/^pk_\w{16}$/', $value ?? '') === 1;
     }
 
     /**

--- a/src/Kernel/ValueObjects/Key/SecretKey.php
+++ b/src/Kernel/ValueObjects/Key/SecretKey.php
@@ -6,6 +6,6 @@ final class SecretKey extends AbstractSecretKey
 {
     protected function validateValue($value)
     {
-        return preg_match('/^sk_\w{16}$/', $value) === 1;
+        return preg_match('/^sk_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Key/TestPublicKey.php
+++ b/src/Kernel/ValueObjects/Key/TestPublicKey.php
@@ -6,6 +6,6 @@ final class TestPublicKey extends AbstractPublicKey
 {
     protected function validateValue($value)
     {
-        return preg_match('/^pk_test_\w{16}$/', $value) === 1;
+        return preg_match('/^pk_test_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/Key/TestSecretKey.php
+++ b/src/Kernel/ValueObjects/Key/TestSecretKey.php
@@ -6,6 +6,6 @@ final class TestSecretKey extends AbstractSecretKey
 {
     protected function validateValue($value)
     {
-        return preg_match('/^sk_test_\w{16}$/', $value) === 1;
+        return preg_match('/^sk_test_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Kernel/ValueObjects/NumericString.php
+++ b/src/Kernel/ValueObjects/NumericString.php
@@ -6,6 +6,6 @@ class NumericString extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^\d*$/', $value) === 1;
+        return preg_match('/^\d*$/', $value ?? '') === 1;
     }
 }

--- a/src/Maintenance/Services/ConfigInfoRetrieverService.php
+++ b/src/Maintenance/Services/ConfigInfoRetrieverService.php
@@ -48,7 +48,7 @@ class ConfigInfoRetrieverService implements InfoRetrieverServiceInterface
             $init = substr($value, 0, $start);
         }
         
-        $obfuscated = preg_replace('/./', $replacement, $value, $limit);
+        $obfuscated = preg_replace('/./', $replacement, $value ?? '', $limit);
 
         return $init . substr($obfuscated, $start);
     }

--- a/src/Maintenance/Services/InstallDataSource/AbstractInstallDataSource.php
+++ b/src/Maintenance/Services/InstallDataSource/AbstractInstallDataSource.php
@@ -33,7 +33,7 @@ abstract class AbstractInstallDataSource implements InstallDataSourceInterface
                     $foundFile = preg_replace(
                         '/\\' .DIRECTORY_SEPARATOR. '{2,}/',
                         DIRECTORY_SEPARATOR,
-                        $foundFile
+                        $foundFile ?? ''
                     );
 
                     if (is_dir($foundFile)) {
@@ -56,7 +56,7 @@ abstract class AbstractInstallDataSource implements InstallDataSourceInterface
         if (strlen($file) < 3) {
             return true;
         }
-        $dir = str_replace($this->getModuleRoot(),'', $path);
+        $dir = str_replace($this->getModuleRoot(),'', $path ?? '');
         return
             $ignoreVendor
             && (

--- a/src/Maintenance/Services/InstallDataSource/ComposerInstallDataSource.php
+++ b/src/Maintenance/Services/InstallDataSource/ComposerInstallDataSource.php
@@ -18,7 +18,7 @@ final class ComposerInstallDataSource
 
         $this->integrityFilePath = $concreteDir . DIRECTORY_SEPARATOR . 'integrityData';
 
-        $composerJsonFilePath = explode(DIRECTORY_SEPARATOR, $concreteDir);
+        $composerJsonFilePath = explode(DIRECTORY_SEPARATOR, $concreteDir ?? '');
         array_pop($composerJsonFilePath);
 
         $this->composerJsonFilePath = implode(DIRECTORY_SEPARATOR, $composerJsonFilePath);
@@ -72,7 +72,7 @@ final class ComposerInstallDataSource
 
     protected function getModuleRoot()
     {
-        $moduleRoot = explode(DIRECTORY_SEPARATOR, $this->composerJsonFilePath);
+        $moduleRoot = explode(DIRECTORY_SEPARATOR, $this->composerJsonFilePath ?? '');
         array_pop($moduleRoot);
         $moduleRoot = implode(DIRECTORY_SEPARATOR, $moduleRoot);
 

--- a/src/Maintenance/Services/InstallDataSource/ModmanInstallDataSource.php
+++ b/src/Maintenance/Services/InstallDataSource/ModmanInstallDataSource.php
@@ -51,18 +51,18 @@ final class ModmanInstallDataSource
         $rawData = file_get_contents($this->modmanFilePath);
 
         $lines = [];
-        preg_match_all('/^(?!#).+/m', $rawData, $lines);
+        preg_match_all('/^(?!#).+/m', $rawData ?? '', $lines);
         $lines = array_pop($lines);
         array_walk(
             $lines, function (&$line) {
-                $data = explode(' ', $line);
+                $data = explode(' ', $line ?? '');
                 $line = end($data);
             }
         );
 
         $platformRootDir = '';
         foreach ($lines as $line) {
-            $platformRootDir = str_replace($line, '', $this->modmanFilePath);
+            $platformRootDir = str_replace($line, '', $this->modmanFilePath ?? '');
             if (strlen($platformRootDir) >= strlen($this->modmanFilePath)) {
                 $platformRootDir = '';
             }
@@ -90,18 +90,18 @@ final class ModmanInstallDataSource
         $rawData = file_get_contents($this->modmanFilePath);
 
         $lines = [];
-        preg_match_all('/^(?!#).+/m', $rawData, $lines);
+        preg_match_all('/^(?!#).+/m', $rawData ?? '', $lines);
         $lines = array_pop($lines);
         array_walk(
             $lines, function (&$line) {
-            $data = explode(' ', $line);
+            $data = explode(' ', $line ?? '');
             $line = end($data);
         }
         );
 
         $platformRootDir = '';
         foreach ($lines as $line) {
-            $platformRootDir = str_replace($line, '', $this->modmanFilePath);
+            $platformRootDir = str_replace($line, '', $this->modmanFilePath ?? '');
             if (strlen($platformRootDir) >= strlen($this->modmanFilePath)) {
                 $platformRootDir = '';
             }

--- a/src/Maintenance/Services/IntegrityInfoRetrieverService.php
+++ b/src/Maintenance/Services/IntegrityInfoRetrieverService.php
@@ -44,7 +44,7 @@ class IntegrityInfoRetrieverService implements InfoRetrieverServiceInterface
         $classes = scandir($installDataSourcesDir);
         array_walk(
             $classes, function (&$class) {
-                $class = str_replace('InstallDataSource.php', '', $class);
+                $class = str_replace('InstallDataSource.php', '', $class ?? '');
             }
         );
         $classes = array_filter(
@@ -92,7 +92,7 @@ class IntegrityInfoRetrieverService implements InfoRetrieverServiceInterface
             $cleanFilename = str_replace(
                 $rootDir,
                 '',
-                $file
+                $file ?? ''
             );
             $fileHashs[$cleanFilename] = $this->generateFileHash($file);
         }
@@ -183,7 +183,7 @@ class IntegrityInfoRetrieverService implements InfoRetrieverServiceInterface
     {
         $dirCount = [];
         foreach ($files as $file) {
-            $explodedPath = explode(DIRECTORY_SEPARATOR, $file);
+            $explodedPath = explode(DIRECTORY_SEPARATOR, $file ?? '');
 
             array_pop($explodedPath);
 
@@ -227,7 +227,7 @@ class IntegrityInfoRetrieverService implements InfoRetrieverServiceInterface
             $cleanFilename = str_replace(
                 $rootDir,
                 '',
-                $file
+                $file ?? ''
             );
             $fileHashs[$cleanFilename] = $this->generateFileHash($file);
         }

--- a/src/Maintenance/Services/LogDownloadInfoRetrieverService.php
+++ b/src/Maintenance/Services/LogDownloadInfoRetrieverService.php
@@ -13,7 +13,7 @@ class LogDownloadInfoRetrieverService implements InfoRetrieverServiceInterface
         $logInfo = $logInfoRetrievierService->retrieveInfo('');
         $validLogFiles = $logInfo->files;
 
-        $params = explode(':', $value);
+        $params = explode(':', $value ?? '');
 
         try {
             $extension = $params[0];
@@ -32,7 +32,7 @@ class LogDownloadInfoRetrieverService implements InfoRetrieverServiceInterface
 
     private function handleDownload($extension, $file)
     {
-        $downloadFileName = str_replace(DIRECTORY_SEPARATOR, "_", $file);
+        $downloadFileName = str_replace(DIRECTORY_SEPARATOR, "_", $file ?? '');
 
         if ($extension != "zip") {
             return $this->downloadLog($downloadFileName, $file);

--- a/src/Maintenance/Services/LogInfoRetrieverService.php
+++ b/src/Maintenance/Services/LogInfoRetrieverService.php
@@ -51,12 +51,12 @@ class LogInfoRetrieverService implements InfoRetrieverServiceInterface
             $uriZip =
                 ltrim(preg_replace(
                     '/' . $needle . '/',
-                    'logDownload=zip:' . $encoded, $requestURI
+                    'logDownload=zip:' . $encoded, $requestURI ?? ''
                 ), '/');
             $uriRaw =
                 ltrim(preg_replace(
                     '/' . $needle . '/',
-                    'logDownload=raw:' . $encoded, $requestURI
+                    'logDownload=raw:' . $encoded, $requestURI ?? ''
                 ), '/');
 
             $donwloadURIs[] = [
@@ -74,7 +74,7 @@ class LogInfoRetrieverService implements InfoRetrieverServiceInterface
 
     private function filterLogFilesByDate($dateQuery, $files)
     {
-        $dates = explode(':', $dateQuery);
+        $dates = explode(':', $dateQuery ?? '');
 
         if (empty($dates)) {
             return $files;
@@ -92,7 +92,7 @@ class LogInfoRetrieverService implements InfoRetrieverServiceInterface
         foreach ($files as $file) {
 
             $matchDate = [];
-            preg_match('/\d{4}-\d{2}-\d{2}/', $file, $matchDate);
+            preg_match('/\d{4}-\d{2}-\d{2}/', $file ?? '', $matchDate);
 
             if (!isset($matchDate[0])) {
                 $result[] = $file;
@@ -124,7 +124,7 @@ class LogInfoRetrieverService implements InfoRetrieverServiceInterface
                     }
 
                     $foundFile = $logDir . DIRECTORY_SEPARATOR . $foundFile;
-                    $foundFile = preg_replace('/\\' .DIRECTORY_SEPARATOR. '{2,}/', DIRECTORY_SEPARATOR, $foundFile);
+                    $foundFile = preg_replace('/\\' .DIRECTORY_SEPARATOR. '{2,}/', DIRECTORY_SEPARATOR, $foundFile ?? '');
 
                     if (is_dir($foundFile)) {
                         $files = array_merge(

--- a/src/Marketplace/Factories/RecipientFactory.php
+++ b/src/Marketplace/Factories/RecipientFactory.php
@@ -82,7 +82,7 @@ class RecipientFactory implements FactoryInterface
     private function getTypeByDocument($document)
     {
         if ($document) {
-            $document = preg_replace("/[^0-9]/", "", $document);
+            $document = preg_replace("/[^0-9]/", "", $document ?? '');
             return strlen($document) > 11 ? 'company' : 'individual';
         }
     }

--- a/src/Payment/Aggregates/Address.php
+++ b/src/Payment/Aggregates/Address.php
@@ -69,7 +69,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
         $numberWithoutComma = str_replace(
             self::ADDRESS_LINE_SEPARATOR,
             '',
-            $number
+            $number ?? ''
         );
 
         $numberWithoutLineBreaks = StringFunctionsHelper::removeLineBreaks(
@@ -110,7 +110,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
         $streetWithoutComma = str_replace(
             self::ADDRESS_LINE_SEPARATOR,
             '',
-            $street
+            $street ?? ''
         );
 
         $streetWithoutLineBreaks = StringFunctionsHelper::removeLineBreaks(
@@ -150,7 +150,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
         $neighborhoodWithoutComma = str_replace(
             self::ADDRESS_LINE_SEPARATOR,
             '',
-            $neighborhood
+            $neighborhood ?? ''
         );
 
         $neighborhoodWithoutLineBreaks = StringFunctionsHelper::removeLineBreaks(
@@ -382,7 +382,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
 
     private function formatZipCode($zipCode)
     {
-        $zipCode = str_replace('-', '', $zipCode);
+        $zipCode = str_replace('-', '', $zipCode ?? '');
         $this->country = $this->country ?? "BR";
         $brazilianZipCodeLength = 8;
         if (strtoupper($this->country) === 'BR') {

--- a/src/Payment/Aggregates/Item.php
+++ b/src/Payment/Aggregates/Item.php
@@ -67,8 +67,8 @@ final class Item extends AbstractEntity implements ConvertibleToSDKRequestsInter
      */
     public function setName($name)
     {
-        if (preg_match('/[^a-zA-Z0-9 ]+/i', $name)) {
-            $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name);
+        if (preg_match('/[^a-zA-Z0-9 ]+/i', $name ?? '')) {
+            $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name ?? '');
         }
         $this->name = $name;
     }

--- a/src/Payment/Aggregates/Order.php
+++ b/src/Payment/Aggregates/Order.php
@@ -102,7 +102,7 @@ final class Order extends AbstractEntity implements ConvertibleToSDKRequestsInte
      */
     public function setPaymentMethod($paymentMethodName)
     {
-        $replace = str_replace('_', '', $paymentMethodName);
+        $replace = str_replace('_', '', $paymentMethodName ?? '');
         $paymentMethodObject = $replace . 'PaymentMethod';
 
         $this->paymentMethod = $this->$paymentMethodObject();
@@ -204,7 +204,7 @@ final class Order extends AbstractEntity implements ConvertibleToSDKRequestsInte
     private function discoverPaymentMethod(AbstractPayment $payment)
     {
         $paymentClass = get_class($payment);
-        $paymentClass = explode ('\\', $paymentClass);
+        $paymentClass = explode ('\\', $paymentClass ?? '');
         $paymentClass = end($paymentClass);
         return $paymentClass;
     }

--- a/src/Payment/Aggregates/Payments/AbstractPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractPayment.php
@@ -121,7 +121,7 @@ implements ConvertibleToSDKRequestsInterface, HaveOrderInterface
 
     private function cammel2SnakeCase($cammelCaseString)
     {
-        preg_match_all('!([A-Z][A-Z0-9]*(?=$|[A-Z][a-z0-9])|[A-Za-z][a-z0-9]+)!', $cammelCaseString, $matches);
+        preg_match_all('!([A-Z][A-Z0-9]*(?=$|[A-Z][a-z0-9])|[A-Za-z][a-z0-9]+)!', $cammelCaseString ?? '', $matches);
         $ret = $matches[0];
         foreach ($ret as &$match) {
             $match = $match == strtoupper($match) ? strtolower($match) : lcfirst($match);

--- a/src/Payment/ValueObjects/CardId.php
+++ b/src/Payment/ValueObjects/CardId.php
@@ -6,6 +6,6 @@ final class CardId extends AbstractCardIdentifier
 {
     protected function validateValue($value)
     {
-        return preg_match('/card_\w{16}$/', $value) === 1;
+        return preg_match('/card_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Payment/ValueObjects/CardToken.php
+++ b/src/Payment/ValueObjects/CardToken.php
@@ -6,6 +6,6 @@ final class CardToken extends AbstractCardIdentifier
 {
     protected function validateValue($value)
     {
-        return preg_match('/token_\w{16}$/', $value) === 1;
+        return preg_match('/token_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Payment/ValueObjects/Phone.php
+++ b/src/Payment/ValueObjects/Phone.php
@@ -23,7 +23,7 @@ final class Phone extends AbstractValueObject implements ConvertibleToSDKRequest
      */
     public function __construct($phone)
     {
-        $phone = preg_replace('/(?!\d)./', '', $phone);
+        $phone = preg_replace('/(?!\d)./', '', $phone ?? '');
         $phone = sprintf("%05s", $phone);
 
         $this->countryCode = new NumericString(55);

--- a/src/Recurrence/Aggregates/SubProduct.php
+++ b/src/Recurrence/Aggregates/SubProduct.php
@@ -129,8 +129,8 @@ class SubProduct extends AbstractEntity implements SubProductEntityInterface
      */
     public function setName($name)
     {
-        if (preg_match('/[^a-zA-Z0-9 ]+/i', $name)) {
-            $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name);
+        if (preg_match('/[^a-zA-Z0-9 ]+/i', $name ?? '')) {
+            $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name ?? '');
         }
 
         $this->name = substr($name, 0, 256);

--- a/src/Recurrence/Factories/TreatFactoryChargeDataBase.php
+++ b/src/Recurrence/Factories/TreatFactoryChargeDataBase.php
@@ -9,24 +9,24 @@ abstract class TreatFactoryChargeDataBase
         $transactions = [];
         if ($dbData['tran_id'] !== null) {
             $tranId = explode(',', $dbData['tran_id']);
-            $tranPagarmeId = explode(',', $dbData['tran_pagarme_id']);
-            $tranChargeId = explode(',', $dbData['tran_charge_id']);
-            $tranAmount = explode(',', $dbData['tran_amount']);
-            $tranPaidAmount = explode(',', $dbData['tran_paid_amount']);
-            $tranType = explode(',', $dbData['tran_type']);
-            $tranStatus = explode(',', $dbData['tran_status']);
-            $tranCreatedAt = explode(',', $dbData['tran_created_at']);
+            $tranPagarmeId = explode(',', $dbData['tran_pagarme_id'] ?? '');
+            $tranChargeId = explode(',', $dbData['tran_charge_id'] ?? '');
+            $tranAmount = explode(',', $dbData['tran_amount'] ?? '');
+            $tranPaidAmount = explode(',', $dbData['tran_paid_amount'] ?? '');
+            $tranType = explode(',', $dbData['tran_type'] ?? '');
+            $tranStatus = explode(',', $dbData['tran_status'] ?? '');
+            $tranCreatedAt = explode(',', $dbData['tran_created_at'] ?? '');
 
-            $tranAcquirerNsu = explode(',', $dbData['tran_acquirer_nsu']);
-            $tranAcquirerTid = explode(',', $dbData['tran_acquirer_tid']);
+            $tranAcquirerNsu = explode(',', $dbData['tran_acquirer_nsu'] ?? '');
+            $tranAcquirerTid = explode(',', $dbData['tran_acquirer_tid'] ?? '');
             $tranAcquirerAuthCode = explode(
                 ',',
-                $dbData['tran_acquirer_auth_code']
-            );
-            $tranAcquirerName = explode(',', $dbData['tran_acquirer_name']);
-            $tranAcquirerMessage = explode(',', $dbData['tran_acquirer_message']);
-            $tranBoletoUrl = explode(',', $dbData['tran_boleto_url']);
-            $tranCardData = explode('---', $dbData['tran_card_data']);
+                $dbData['tran_acquirer_auth_code'] ?? ''
+             );
+            $tranAcquirerName = explode(',', $dbData['tran_acquirer_name'] ?? '');
+            $tranAcquirerMessage = explode(',', $dbData['tran_acquirer_message'] ?? '');
+            $tranBoletoUrl = explode(',', $dbData['tran_boleto_url'] ?? '');
+            $tranCardData = explode('---', $dbData['tran_card_data'] ?? '');
 
             foreach ($tranId as $index => $id) {
                 $transaction = [

--- a/src/Recurrence/Services/SubscriptionService.php
+++ b/src/Recurrence/Services/SubscriptionService.php
@@ -462,7 +462,7 @@ final class SubscriptionService
     private function getResponseHandler($response)
     {
         $responseClass = get_class($response);
-        $responseClass = explode('\\', $responseClass);
+        $responseClass = explode('\\', $responseClass ?? '');
 
         $responseClass =
             'Pagarme\\Core\\Recurrence\\Services\\ResponseHandlers\\' .

--- a/src/Recurrence/ValueObjects/InvoiceIdValueObject.php
+++ b/src/Recurrence/ValueObjects/InvoiceIdValueObject.php
@@ -8,6 +8,6 @@ class InvoiceIdValueObject extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/in_\w{16}$/', $value) === 1;
+        return preg_match('/in_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Recurrence/ValueObjects/PlanId.php
+++ b/src/Recurrence/ValueObjects/PlanId.php
@@ -8,6 +8,6 @@ class PlanId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^plan_\w{16}$/', $value) === 1;
+        return preg_match('/^plan_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Recurrence/ValueObjects/PlanItemId.php
+++ b/src/Recurrence/ValueObjects/PlanItemId.php
@@ -8,6 +8,6 @@ class PlanItemId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^pi_\w{16}$/', $value) === 1;
+        return preg_match('/^pi_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Recurrence/ValueObjects/SubscriptionItemId.php
+++ b/src/Recurrence/ValueObjects/SubscriptionItemId.php
@@ -8,6 +8,6 @@ class SubscriptionItemId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/^si_\w{16}$/', $value) === 1;
+        return preg_match('/^si_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Webhook/Services/AbstractHandlerService.php
+++ b/src/Webhook/Services/AbstractHandlerService.php
@@ -20,7 +20,7 @@ abstract class AbstractHandlerService
 
     public function getActionHandle($action)
     {
-        $baseActions = explode('_', $action);
+        $baseActions = explode('_', $action ?? '');
         $action = '';
         foreach ($baseActions as $baseAction) {
             $action .= ucfirst($baseAction);
@@ -81,7 +81,7 @@ abstract class AbstractHandlerService
     protected function getValidEntity()
     {
         $childClassName = substr(strrchr(static::class, "\\"), 1);
-        $childEntity = str_replace('HandlerService', '', $childClassName);
+        $childEntity = str_replace('HandlerService', '', $childClassName ?? '');
         return strtolower($childEntity);
     }
 

--- a/src/Webhook/ValueObjects/WebhookId.php
+++ b/src/Webhook/ValueObjects/WebhookId.php
@@ -8,6 +8,6 @@ class WebhookId extends AbstractValidString
 {
     protected function validateValue($value)
     {
-        return preg_match('/hook_\w{16}$/', $value) === 1;
+        return preg_match('/hook_\w{16}$/', $value ?? '') === 1;
     }
 }

--- a/src/Webhook/ValueObjects/WebhookType.php
+++ b/src/Webhook/ValueObjects/WebhookType.php
@@ -26,7 +26,7 @@ final class WebhookType extends AbstractValueObject
 
     static public function fromPostType($postType)
     {
-        $data = explode('.', $postType);
+        $data = explode('.', $postType ?? '');
         return new self($data[0], $data[1]);
     }
 

--- a/tests/Kernel/ValueObjects/OrderStateTest.php
+++ b/tests/Kernel/ValueObjects/OrderStateTest.php
@@ -56,7 +56,7 @@ class OrderStateTest extends TestCase
 
         foreach ($constants as $const => $state) {
             $const = strtolower($const);
-            $const = explode('_', $const);
+            $const = explode('_', $const ?? '');
             foreach ($const as &$c) {
                 $c = ucfirst($c);
             }

--- a/tests/Kernel/ValueObjects/ValidStringTestTrait.php
+++ b/tests/Kernel/ValueObjects/ValidStringTestTrait.php
@@ -10,7 +10,7 @@ trait ValidStringTestTrait
     {
         $class = self::class;
         $class = substr($class, 0, strlen($class) -4);
-        $class = str_replace('\\Test\\', '\\', $class);
+        $class = str_replace('\\Test\\', '\\', $class ?? '');
 
         $validStringObject = new $class(self::VALID1);
         $this->assertEquals(self::VALID1, $validStringObject->getValue());

--- a/tests/mock/ValidStringMock.php
+++ b/tests/mock/ValidStringMock.php
@@ -14,6 +14,6 @@ class ValidStringMock extends AbstractValidString
 
     protected function validateValue($value)
     {
-        return preg_match(self::VALIDATION_REGEX, $value) === 1;
+        return preg_match(self::VALIDATION_REGEX, $value ?? '') === 1;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**           | https://mundipagg.atlassian.net/browse/PAOPN-355
| **What?**         | Fixed deprecated "Passing null to parameter" on functions in PHP8
| **Why?**          | To avoid exceptions ion this situations
| **How?**          | By adding `?? ''` to functions that expect strings