### PR TITLE
PAOPN-425: Removing unnecessary configurations update in bootstrap

### DIFF
--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -110,7 +110,6 @@ abstract class AbstractModuleCoreSetup
             static::$moduleConfig->setInheritAll(true);
             static::$moduleConfig->setId(null);
         }
-        static::saveModuleConfig();
     }
 
     protected static function saveModuleConfig()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-425
| **What?**         | Removing unnecessary configurations update in bootstrap.
| **Why?**          | Updating configurations in every bootstrap call without needing.
| **How?**          | Removing unnecessary configurations update in bootstrap.

