### PR TITLE
feat: compatibilization with magento 2.4.6 and PHP 8.2

### DIFF
--- a/src/Marketplace/Services/RecipientService.php
+++ b/src/Marketplace/Services/RecipientService.php
@@ -2,6 +2,7 @@
 
 namespace Pagarme\Core\Marketplace\Services;
 
+use Pagarme\Core\Kernel\Aggregates\Configuration as ConfigurationAggregate;
 use PagarmeCoreApiLib\APIException;
 use PagarmeCoreApiLib\Models\UpdateRecipientBankAccountRequest;
 use PagarmeCoreApiLib\Models\UpdateRecipientRequest;
@@ -19,15 +20,35 @@ use Pagarme\Core\Marketplace\Repositories\RecipientRepository;
 
 class RecipientService
 {
-    /** @var LogService  */
+    /**
+     * @var LogService
+     */
     protected $logService;
-    /** @var RecipientFactory */
+
+    /**
+     * @var RecipientFactory
+     */
     protected $recipientFactory;
-    /** @var RecipientRepository */
+
+    /**
+     * @var RecipientRepository
+     */
     protected $recipientRepository;
 
+    /**
+     * @var ConfigurationAggregate
+     */
     protected $config;
+
+    /**
+     * @var LocalizationService
+     */
     protected $i18n;
+
+    /**
+     * @var PagarmeCoreApiClient
+     */
+    protected $pagarmeCoreApi;
 
     public function __construct()
     {

--- a/src/Payment/Aggregates/Address.php
+++ b/src/Payment/Aggregates/Address.php
@@ -386,7 +386,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
         $this->country = $this->country ?? "BR";
         $brazilianZipCodeLength = 8;
         if (strtoupper($this->country) === 'BR') {
-            $zipCode = sprintf("%0${brazilianZipCodeLength}s", $zipCode);
+            $zipCode = sprintf("%0{$brazilianZipCodeLength}s", $zipCode);
             $zipCode = substr($zipCode, 0, $brazilianZipCodeLength);
             return $zipCode;
         }

--- a/src/Payment/Factories/PaymentFactory.php
+++ b/src/Payment/Factories/PaymentFactory.php
@@ -134,7 +134,7 @@ final class PaymentFactory
 
         $payment->setAmount($cardData->amount);
         $payment->setInstallments($cardData->installments);
-        $payment->setRecurrenceCycle($cardData->recurrenceCycle ?? '');
+        $payment->setRecurrenceCycle($cardData->recurrenceCycle ?? null);
 
         //setting amount with interest
         if (strcmp($cardDataIndex, \Pagarme\Core\Kernel\ValueObjects\PaymentMethod::VOUCHER)) {

--- a/src/Recurrence/Services/CartRules/CurrentProduct.php
+++ b/src/Recurrence/Services/CartRules/CurrentProduct.php
@@ -8,10 +8,30 @@ use Pagarme\Core\Recurrence\Interfaces\RepetitionInterface;
 
 class CurrentProduct
 {
+    /**
+     * @var bool
+     */
     protected $isNormalProduct = false;
+
+    /**
+     * @var RepetitionInterface
+     */
     protected $repetitionSelected;
+
+    /**
+     * @var ProductSubscriptionInterface
+     */
     protected $productSubscriptionSelected;
+
+    /**
+     * @var ProductPlanInterface
+     */
     protected $productPlanSelected;
+
+    /**
+     * @var int
+     */
+    protected $quantity;
 
     /**
      * @return RepetitionInterface

--- a/src/Recurrence/Services/PlanService.php
+++ b/src/Recurrence/Services/PlanService.php
@@ -16,6 +16,11 @@ use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup;
 
 class PlanService
 {
+    /**
+     * @var PagarmeCoreApiClient
+     */
+    private $pagarmeCoreApiClient;
+
     public function __construct()
     {
         AbstractModuleCoreSetup::bootstrap();

--- a/src/Webhook/Aggregates/Webhook.php
+++ b/src/Webhook/Aggregates/Webhook.php
@@ -20,6 +20,11 @@ class Webhook extends AbstractEntity
     protected $entity;
 
     /**
+     * @var string
+     */
+    protected $component;
+
+    /**
      *
      * @return WebhookType
      */

--- a/tests/Marketplace/Aggregates/SplitTest.php
+++ b/tests/Marketplace/Aggregates/SplitTest.php
@@ -9,7 +9,7 @@ class SplitTest extends TestCase
 {
     private $split;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->split = new Split();
     }

--- a/tests/Recurrence/Aggregates/SubscriptionTest.php
+++ b/tests/Recurrence/Aggregates/SubscriptionTest.php
@@ -201,11 +201,6 @@ class SubscriptionTest extends TestCase
 
         $this->subscription->setShipping($shipping);
 
-        $card = new CreateCardRequest();
-        $card->billingAddress = $this->subscription->getCustomer()
-            ->getAddress()->convertToSDKRequest();
-        $this->subscription->card = $card;
-
         $sdkObject = $this->subscription->convertToSdkRequest();
 
         $this->assertInstanceOf(CreateSubscriptionRequest::class, $sdkObject);
@@ -224,11 +219,6 @@ class SubscriptionTest extends TestCase
         $shipping->setAddress(new Address());
 
         $this->subscription->setShipping($shipping);
-
-        $card = new CreateCardRequest();
-        $card->billingAddress = $this->subscription->getCustomer()
-            ->getAddress()->convertToSDKRequest();
-        $this->subscription->card = $card;
 
         $sdkObject = $this->subscription->convertToSdkRequest();
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-393
| **What?**         | Compatibilization with magento 2.4.6 and PHP 8.2.
| **Why?**          | Work with more versions.
| **How?**          | Adding properties definition to compatibilize with PHP 8.2.

