### PR TITLE
feat: removing parentheses from cycle title builder

### DIFF
--- a/src/Recurrence/Services/RepetitionService.php
+++ b/src/Recurrence/Services/RepetitionService.php
@@ -62,7 +62,7 @@ class RepetitionService
 
         $totalAmount = $numberFormatter->format($totalAmount);
 
-        return $intervalLabel . " - ({$totalAmount})";
+        return $intervalLabel . " - {$totalAmount}";
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-548
| **What?**         | Removing parentheses from cycle title builder.
| **Why?**          | Conflict with other magento product options that use parentheses.
| **How?**          | Removing parentheses from cycle title builder.

