### PR TITLE
Fix log to files stoping the order flow

### DIFF
--- a/src/Kernel/Log/BlurData.php
+++ b/src/Kernel/Log/BlurData.php
@@ -31,7 +31,7 @@ class BlurData
      * @param $delimiter
      * @return string
      */
-    private function blurStringSensitiveData(string $value, $delimiter)
+    private function blurStringSensitiveData(string $value = "", $delimiter)
     {
         $displayed = substr($value, 0, $delimiter);
         $blur = str_repeat("*", strlen($value));

--- a/src/Kernel/Services/LogService.php
+++ b/src/Kernel/Services/LogService.php
@@ -75,9 +75,16 @@ class LogService
      */
     public function info($message, $sourceObject = null)
     {
-        $logObject = $this->prepareObject($sourceObject);
-        $logObject = $this->blurSensitiveData($logObject);
-        $this->monolog->info($message, $logObject);
+        try {
+
+            $logObject = $this->prepareObject($sourceObject);
+            $logObject = $this->blurSensitiveData($logObject);
+            $this->monolog->info($message, $logObject);
+
+        } catch (\Throwable $th) {
+            //throw $th;
+        }
+
     }
 
     /**
@@ -86,9 +93,15 @@ class LogService
      */
     public function exception(\Exception $exception)
     {
-        $logObject = $this->prepareObject($exception);
-        $code = ' | Exception code: ' . $exception->getCode();
-        $this->monolog->error($exception->getMessage() . $code, $logObject);
+        try {
+
+            $logObject = $this->prepareObject($exception);
+            $code = ' | Exception code: ' . $exception->getCode();
+            $this->monolog->error($exception->getMessage() . $code, $logObject);
+            
+        } catch (\Throwable $th) {
+            //throw $th;
+        }
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://github.com/pagarme/magento2/issues/168
| **What?**         | Set the first argument  fom blurStringSensitiveData to optional, and updated Log service to not throw  an exception and stop the current order flow.
| **Why?**          | To not have inconsistencies between the platforms because the module failed to log for some reason.
| **How?**          | Setting the first argument  fom blurStringSensitiveData to optional, and updated Log service to not throw an exception and stop the current order flow.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)
![image](https://github.com/pagarme/magento2/assets/18008565/d75671cd-4433-4a4a-89be-2dfb6920636d)
#
![image](https://github.com/pagarme/magento2/assets/18008565/8bd5290c-69c4-4a38-9e3a-dd0dc115a9a4)


#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
