### PR TITLE
fix: add default value to blurStringSensitiveData parameter

### DIFF
--- a/src/Kernel/Log/BlurData.php
+++ b/src/Kernel/Log/BlurData.php
@@ -28,16 +28,17 @@ class BlurData
 
     /**
      * @param string $value
-     * @param $delimiter
+     * @param int $delimiter
      * @return string
      */
-    private function blurStringSensitiveData(string $value = "", $delimiter = null)
+    private function blurStringSensitiveData($value, $delimiter)
     {
+        if (empty($value)) {
+            return '';
+        }
         $displayed = substr($value, 0, $delimiter);
-        $blur = str_repeat("*", strlen($value));
-        $blur = substr($blur, $delimiter);
-        $result = "$displayed $blur";
-        return $result;
+        $blur = str_repeat("*", strlen($value) - $delimiter);
+        return $displayed . $blur;
     }
 
     /**

--- a/src/Kernel/Log/BlurData.php
+++ b/src/Kernel/Log/BlurData.php
@@ -31,7 +31,7 @@ class BlurData
      * @param $delimiter
      * @return string
      */
-    private function blurStringSensitiveData(string $value = "", $delimiter)
+    private function blurStringSensitiveData(string $value = "", $delimiter = null)
     {
         $displayed = substr($value, 0, $delimiter);
         $blur = str_repeat("*", strlen($value));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Defined default value to blurStringSensitiveData `$delimiter` parameter
| **Why?**          | To fix deprecated functionality
| **How?**          | Defining default value as `null`