### PR TITLE
fix: adding due_at, bank and instructions information to be send to createOrder for billet payment method

### DIFF
--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -679,7 +679,7 @@ final class Configuration extends AbstractEntity
     /**
      * @return string
      */
-    protected function getBoletoInstructions()
+    public function getBoletoInstructions()
     {
         return $this->boletoInstructions;
     }

--- a/src/Payment/Factories/PaymentFactory.php
+++ b/src/Payment/Factories/PaymentFactory.php
@@ -32,12 +32,6 @@ final class PaymentFactory
     /** @var string */
     private $cardStatementDescriptor;
 
-    /** @var BoletoBank */
-    private $boletoBank;
-
-    /** @var string */
-    private $boletoInstructions;
-
     public function __construct()
     {
         $this->primitiveFactories = [
@@ -51,8 +45,6 @@ final class PaymentFactory
         $this->moduleConfig = MPSetup::getModuleConfiguration();
 
         $this->cardStatementDescriptor = $this->moduleConfig->getCardStatementDescriptor();
-        $this->boletoBank = BoletoBank::itau();
-        $this->boletoInstructions = $this->moduleConfig->getBoletoInstructions();
     }
 
     public function createFromJson($json)
@@ -230,8 +222,14 @@ final class PaymentFactory
             }
 
             $payment->setAmount($boletoData->amount);
-            $payment->setBank($this->boletoBank);
-            $payment->setInstructions($this->boletoInstructions);
+            if (property_exists($boletoData, 'bank')) {
+                $bank = BoletoBank::createFromCode($boletoData->bank);
+                if ($bank) {
+                    $payment->setBank($bank);
+                }
+            }
+            $payment->setInstructions($boletoData->instructions);
+            $payment->setDueAt($boletoData->due_at);
 
             $payments[] = $payment;
         }

--- a/src/Payment/ValueObjects/BoletoBank.php
+++ b/src/Payment/ValueObjects/BoletoBank.php
@@ -88,6 +88,32 @@ class BoletoBank extends AbstractValueObject
         return new self(self::CODE_CEF, self::NAME_CEF);
     }
 
+    static public function createFromCode($code) {
+        $billetBank = null;
+        switch ($code) {
+            case self::CODE_BB:
+                $billetBank = self::bb();
+                break;
+            case self::CODE_SANTANDER:
+                $billetBank = self::santander();
+                break;
+            case self::CODE_BRADESCO:
+                $billetBank = self::bradesco();
+                break;
+            case self::CODE_ITAU:
+                $billetBank = self::itau();
+                break;
+            case self::CODE_CITIBANK:
+                $billetBank = self::citibank();
+                break;
+            case self::CODE_CEF:
+                $billetBank = self::cef();
+                break;
+        }
+
+        return $billetBank;
+    }
+
     /**
      * To check the structural equality of value objects,
      * this method should be implemented in this class children.
@@ -112,11 +138,11 @@ class BoletoBank extends AbstractValueObject
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-       $obj = new \stdClass();
+        $obj = new \stdClass();
 
-       $obj->code = $this->getCode();
-       $obj->name = $this->getName();
+        $obj->code = $this->getCode();
+        $obj->name = $this->getName();
 
-       return $obj;
+        return $obj;
     }
 }

--- a/src/Recurrence/Services/ResponseHandlers/ErrorExceptionHandler.php
+++ b/src/Recurrence/Services/ResponseHandlers/ErrorExceptionHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pagarme\Core\Payment\Services\ResponseHandlers;
+namespace Pagarme\Core\Recurrence\Services\ResponseHandlers;
 
 use Pagarme\Core\Kernel\Services\LocalizationService;
 use Pagarme\Core\Payment\Aggregates\Order as PaymentOrder;

--- a/tests/Recurrence/Aggregates/ProductSubscriptionTest.php
+++ b/tests/Recurrence/Aggregates/ProductSubscriptionTest.php
@@ -56,17 +56,6 @@ class ProductSubscriptionTest extends TestCase
         $this->assertCount(2, $this->productSubscription->getRepetitions());
     }
 
-    /**
-     * TODO: refactor ProductSubscription to return InvalidParamException
-     * @requires PHP >= 7.0
-     * @expectedException \TypeError
-     */
-    public function testShouldThrowAnTypeErrorExceptionIfAddAnWrongTypeOfRepetition()
-    {
-        $this->expectError(\TypeError::class);
-        $this->productSubscription->addRepetition("WrongType");
-    }
-
     public function testShouldReturnTheRecurrenceType()
     {
         $this->assertEquals(

--- a/tests/mock/Concrete/Migrate.php
+++ b/tests/mock/Concrete/Migrate.php
@@ -36,17 +36,17 @@ class Migrate
     public function runConfigurationMigration()
     {
         $this->db->exec("CREATE TABLE IF NOT EXISTS pagarme_module_core_configuration (
-                      id INTEGER PRIMARY KEY, 
-                      data TEXT, 
+                      id INTEGER PRIMARY KEY,
+                      data TEXT,
                       store_id TEXT)");
 
-        $insert = "INSERT INTO pagarme_module_core_configuration (data, store_id) 
+        $insert = "INSERT INTO pagarme_module_core_configuration (data, store_id)
                 VALUES  (:data, :store_id)";
 
         $stmt = $this->db->prepare($insert);
 
         $config = json_encode([
-           "enabled" => true
+            "enabled" => true
         ]);
 
         $stmt->bindValue(':data', $config, SQLITE3_TEXT);
@@ -63,15 +63,16 @@ class Migrate
     public function upRecurrenceProductSubscription()
     {
         $this->db->exec("CREATE TABLE IF NOT EXISTS pagarme_module_core_recurrence_products_subscription (
-                      id INTEGER PRIMARY KEY, 
-                      product_id INTEGER NULLABLE , 
-                      credit_card TEXT NULLABLE, 
-                      allow_installments TEXT NULLABLE, 
-                      boleto BOOLEAN NULLABLE, 
+                      id INTEGER PRIMARY KEY,
+                      product_id INTEGER NULLABLE ,
+                      credit_card TEXT NULLABLE,
+                      allow_installments TEXT NULLABLE,
+                      boleto BOOLEAN NULLABLE,
                       sell_as_normal_product TEXT NULLABLE,
-                      billing_type TEXT NULLABLE NULLABLE, 
-                      created_at TIMESTAMP, 
-                      updated_at TIMESTAMP)");
+                      billing_type TEXT NULLABLE NULLABLE,
+                      created_at TIMESTAMP,
+                      updated_at TIMESTAMP,
+                      apply_discount_in_all_product_cycles INTEGER NULLABLE)");
 
     }
 
@@ -83,13 +84,13 @@ class Migrate
     public function upRecurrenceSubscriptionRepetitions()
     {
         $this->db->exec("CREATE TABLE IF NOT EXISTS pagarme_module_core_recurrence_subscription_repetitions (
-                      id INTEGER PRIMARY KEY, 
-                      subscription_id INTEGER NULLABLE , 
-                      `interval` TEXT NULLABLE, 
-                      interval_count INTEGER NULLABLE, 
+                      id INTEGER PRIMARY KEY,
+                      subscription_id INTEGER NULLABLE ,
+                      `interval` TEXT NULLABLE,
+                      interval_count INTEGER NULLABLE,
                       recurrence_price INTEGER NULLABLE,
                       cycles INTEGER NULLABLE,
-                      created_at TIMESTAMP, 
+                      created_at TIMESTAMP,
                       updated_at TIMESTAMP)");
     }
 
@@ -108,7 +109,7 @@ class Migrate
                       cycles INTEGER NULLABLE,
                       quantity INTEGER NULLABLE,
                       trial_period_days INTEGER NULLABLE,
-                      pagarme_id    TEXT, 
+                      pagarme_id    TEXT,
                       created_at TIMESTAMP,
                       updated_at TIMESTAMP)");
     }
@@ -124,7 +125,7 @@ class Migrate
         create table if not exists pagarme_module_core_recurrence_charge
         (
             id              INTEGER PRIMARY KEY,
-            pagarme_id    TEXT, 
+            pagarme_id    TEXT,
             subscription_id TEXT,
             invoice_id      TEXT,
             code            TEXT,
@@ -132,7 +133,7 @@ class Migrate
             paid_amount     INTEGER,
             canceled_amount INTEGER,
             refunded_amount INTEGER,
-            status          TEXT, 
+            status          TEXT,
             metadata        TEXT,
             payment_method  TEXT,
             boleto_link     TEXT,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-608
| **What?**         | Adding due_at, bank and instructions information to be send to createOrder for billet payment method.
| **Why?**          | Send correct information to create billet order.
| **How?**          | Adding due_at, bank and instructions information to be send to createOrder for billet payment method.
