### PR TITLE
fix: cedilla substr generate specials unicode block

### DIFF
--- a/src/Kernel/Log/BlurData.php
+++ b/src/Kernel/Log/BlurData.php
@@ -36,8 +36,8 @@ class BlurData
         if (empty($value)) {
             return '';
         }
-        $displayed = substr($value, 0, $delimiter);
-        $blur = str_repeat("*", strlen($value) - $delimiter);
+        $displayed = mb_substr($value, 0, $delimiter);
+        $blur = str_repeat("*", mb_strlen($value) - $delimiter);
         return $displayed . $blur;
     }
 
@@ -47,8 +47,8 @@ class BlurData
      */
     private function blurEmailSensitiveData($string)
     {
-        $displayed = substr($string, 0, 3);
-        $final = substr($string, strpos($string, "@"));
+        $displayed = mb_substr($string, 0, 3);
+        $final = mb_substr($string, mb_strpos($string, "@"));
         $result = "$displayed***$final";
         return $result;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-660
| **What?**         | Cedilla substr generate specials unicode block.
| **Why?**          | Generated log for order request and response are written with null value.
| **How?**          | Change str functions to be mb_str

