### PR TITLE
feat: alternate pix and billet info

### DIFF
--- a/src/Kernel/Aggregates/Order.php
+++ b/src/Kernel/Aggregates/Order.php
@@ -104,6 +104,24 @@ final class Order extends AbstractEntity
         return $this->charges;
     }
 
+
+    /**
+     *
+     * @return Transaction|null
+     */
+    public function getPixOrBilletTransaction()
+    {
+        foreach ($this->getCharges() as $charge) {
+            foreach ($charge->getTransactions() as $transaction) {
+                $type = $transaction->getTransactionType()->getType();
+                if ($type === 'pix' || $type === 'boleto') {
+                    return $transaction;
+                }
+            }
+        }
+        return null;
+    }
+
     public function applyOrderStatusFromCharges()
     {
         if (empty($this->getCharges())) {


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **stg**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Adicionado método alternativo para buscar as informações de QrCode de Pix ou URL de Boleto. Ver tarefa: https://mundipagg.atlassian.net/browse/PAOPN-663


### Cenários testados
Defini `null` no `$orderId` para testar o retorno da nova função quando a original falhar. Retorno está conforme esperado. Testado pedidos com Pix, Boleto e Cartão de Crédito. Todos ok!