### PR TITLE
Fixes the problem when sum of split's amounts is not equal to the order total amount

### DIFF
--- a/src/Payment/Aggregates/Payments/AbstractPayment.php
+++ b/src/Payment/Aggregates/Payments/AbstractPayment.php
@@ -102,13 +102,13 @@ implements ConvertibleToSDKRequestsInterface, HaveOrderInterface
 
         $splitMainRecipient = new Split();
 
+	$splitMainRecipient->setCommission(
+		$this->getAmount() - $sellersTotalCommission
+	);
+
         $splitMainRecipient->setRecipientId($this->moduleConfig->getMarketplaceConfig()->getMainRecipientId());
         $splitMainRecipientRequest = $splitMainRecipient
             ->convertMainToSDKRequest();
-
-        $splitMainRecipient->setCommission(
-            $this->getAmount() - $sellersTotalCommission
-        );
 
         return [$splitMainRecipientRequest, $splitRecipientRequests];
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/CONECT-{ISSUE-NUMBER}
| **What?**         | Describe in an objective way what has been done.
| **Why?**          | I am using the woocommerce plugin and i had a problem when splitting the order with intereset on installments. The AbstractPayment recalculates the split amount before sending the request to Pagar.me and sometimes those new values did not sum up correctly because of the round function. It always miss calculate by 1 centavo.
| **How?**          | I just calculate the sellers commission first and then subtract it from the total amount of the payment.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)

In a order of 100 centavos total with 1.15% interest, my wordpress plugins sends this to AbstractPayment: 

[{"marketplaceCommission":50,"commission":50,"pagarmeId":"re_pagarme_id"}]

And this is what is sent to pagar.me

```[
  {
    "type": "flat",
    "amount": 58,
    "recipient_id": "re_pagarme_id",
    "options": {
      "liable": true,
      "charge_processing_fee": true,
      "charge_remainder_fee": true
    },
    "split_rule_id": null
  },
  [
    {
      "type": "flat",
      "amount": 58,
      "recipient_id": "re_pagarme_id",
      "options": {
        "liable": true,
        "charge_processing_fee": false,
        "charge_remainder_fee": false
      },
      "split_rule_id": null
    }
  ]
]```

Notice that with 1.15 intereset on an 100 centavos order, the total should be 115 but the split data sums up to 116

