### PR TITLE
Feat: Add PaymentProfileId to Configuration entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "mockery/mockery": "1.2.4",
-        "nesbot/carbon": "*",
+        "nesbot/carbon": "^3.11",
         "ext-pdo": "*",
         "phpunit/phpunit": "^5 | ^6 | ^7 | ^8 | ^9"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "mockery/mockery": "1.2.4",
-        "nesbot/carbon": "1.39.0",
+        "nesbot/carbon": "*",
         "ext-pdo": "*",
         "phpunit/phpunit": "^5 | ^6 | ^7 | ^8 | ^9"
     },

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -740,7 +740,7 @@ final class Configuration extends AbstractEntity
      */
     public function setAntifraudMinAmount($antifraudMinAmount)
     {
-        $numbers = '/([^0-9])/i';
+        $numbers = '/[^0-9\-]|(?<=.)-/';
         $replace = '';
 
         $minAmount = preg_replace($numbers, $replace, $antifraudMinAmount ?? '');
@@ -748,6 +748,7 @@ final class Configuration extends AbstractEntity
         if ($minAmount < 0) {
             $minAmount = 0;
         }
+
         $this->antifraudMinAmount = $minAmount;
     }
 

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Pagarme\Core\Kernel\Aggregates;
 
-use Magento\Tests\NamingConvention\true\string;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\Helper\StringFunctionsHelper;

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -2,90 +2,91 @@
 
 namespace Pagarme\Core\Kernel\Aggregates;
 
-use Exception;
+use Magento\Tests\NamingConvention\true\string;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\Helper\StringFunctionsHelper;
 use Pagarme\Core\Kernel\ValueObjects\AbstractValidString;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\AddressAttributes;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\CardConfig;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\DebitConfig;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\GooglePayConfig;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\MarketplaceConfig;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\PixConfig;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\RecurrenceConfig;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\VoucherConfig;
-use Pagarme\Core\Kernel\ValueObjects\Configuration\DebitConfig;
-use Pagarme\Core\Kernel\ValueObjects\Configuration\GooglePayConfig;
-use Pagarme\Core\Kernel\ValueObjects\Key\AbstractSecretKey;
-use Pagarme\Core\Kernel\ValueObjects\Key\AbstractPublicKey;
-use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
 use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
+use Pagarme\Core\Kernel\ValueObjects\Key\AbstractPublicKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\AbstractSecretKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
+use ReturnTypeWillChange;
 
 final class Configuration extends AbstractEntity
 {
     const KEY_SECRET = 'KEY_SECRET';
     const KEY_PUBLIC = 'KEY_PUBLIC';
-
     const CARD_OPERATION_AUTH_ONLY = 'auth_only';
     const CARD_OPERATION_AUTH_AND_CAPTURE = 'auth_and_capture';
 
     /**
-     *
      * @var bool
      */
     private $enabled;
+
     /**
-     *
      * @var bool
      */
     private $boletoEnabled;
+
     /**
-     *
      * @var bool
      */
     private $creditCardEnabled;
-    private $googlepayEnabled;
+
     /**
-     *
+     * @var bool
+     */
+    private $googlepayEnabled;
+
+    /**
      * @var bool
      */
     private $twoCreditCardsEnabled;
+
     /**
-     *
      * @var bool
      */
     private $boletoCreditCardEnabled;
+
     /**
-     *
      * @var bool
      */
     private $testMode;
+
     /**
-     *
      * @var GUID
      */
     private $hubInstallId;
 
     /**
-     *
      * @var string
      */
     private $hubEnvironment;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $cardOperation;
 
     /**
-     *
      * @var AbstractValidString[]
      */
     private $keys;
 
     /**
-     *
      * @var CardConfig[]
      */
     private $cardConfigs;
-
 
     /**
      * @var bool
@@ -97,52 +98,84 @@ final class Configuration extends AbstractEntity
      */
     private $antifraudMinAmount;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     private $installmentsEnabled;
 
-    /** @var AddressAttributes */
+    /**
+     * @var AddressAttributes
+     */
     private $addressAttributes;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     private $allowNoAddress;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $cardStatementDescriptor;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $boletoInstructions;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $storeId;
 
-    /** @var Configuration */
+    /**
+     * @var Configuration
+     */
     private $parentConfiguration;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private $methodsInherited;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     private $inheritAll;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     private $saveCards;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     private $saveVoucherCards;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     private $multiBuyer;
 
-    /** @var RecurrenceConfig */
+    /**
+     * @var RecurrenceConfig
+     */
     private $recurrenceConfig;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     private $installmentsDefaultConfig;
 
-    /** @var int */
+    /**
+     * @var int
+     */
     private $boletoDueDays;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $boletoBankCode;
 
     /**
@@ -155,11 +188,19 @@ final class Configuration extends AbstractEntity
      */
     private $createOrderEnabled;
 
-    /** @var VoucherConfig */
+    /**
+     * @var VoucherConfig
+     */
     private $voucherConfig;
 
-    /** @var DebitConfig */
+    /**
+     * @var DebitConfig
+     */
     private $debitConfig;
+
+    /**
+     * @var GooglePayConfig
+     */
     private $googlePayConfig;
 
     /**
@@ -173,9 +214,14 @@ final class Configuration extends AbstractEntity
     private $merchantId;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $accountId;
+
+    /**
+     * @var string|null
+     */
+    private $paymentProfileId;
 
     /**
      * @var MarketplaceConfig
@@ -225,6 +271,9 @@ final class Configuration extends AbstractEntity
         return $this->debitConfig;
     }
 
+    /**
+     * @return GooglePayConfig
+     */
     public function getGooglePayConfig()
     {
         return $this->googlePayConfig;
@@ -237,6 +286,7 @@ final class Configuration extends AbstractEntity
     {
         $this->googlePayConfig = $googlePayConfig;
     }
+
     /**
      * @param DebitConfig $debitConfig
      */
@@ -287,37 +337,76 @@ final class Configuration extends AbstractEntity
 
     /**
      * @param VoucherConfig $voucherConfig
+     * @return void
      */
     public function setVoucherConfig(VoucherConfig $voucherConfig)
     {
         $this->voucherConfig = $voucherConfig;
     }
 
+    /**
+     * @param string|null $accountId
+     * @return void
+     */
     public function setAccountId($accountId)
     {
         $this->accountId = $accountId;
     }
 
+    /**
+     * @return string|null
+     */
     public function getAccountId()
     {
         return $this->accountId;
     }
 
+    /**
+     * @param $merchantId
+     * @return void
+     */
     public function setMerchantId($merchantId)
     {
         $this->merchantId = $merchantId;
     }
 
+    /**
+     * @return string
+     */
     public function getMerchantId()
     {
         return $this->merchantId;
     }
 
+    /**
+     * @param string|null $paymentProfileId
+     * @return void
+     */
+    public function setPaymentProfileId($paymentProfileId)
+    {
+        $this->paymentProfileId = $paymentProfileId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPaymentProfileId()
+    {
+        return $this->paymentProfileId;
+    }
+
+    /**
+     * @return bool
+     */
     protected function isEnabled()
     {
         return $this->enabled;
     }
 
+    /**
+     * @param $enabled
+     * @return void
+     */
     public function setEnabled($enabled)
     {
         $this->enabled = filter_var(
@@ -326,19 +415,24 @@ final class Configuration extends AbstractEntity
         );
     }
 
+    /**
+     * @return AbstractValidString|null
+     */
     protected function getPublicKey()
     {
         return $this->keys[self::KEY_PUBLIC];
     }
 
+    /**
+     * @return AbstractValidString|null
+     */
     protected function getSecretKey()
     {
         return $this->keys[self::KEY_SECRET];
     }
 
     /**
-     *
-     * @param string|array $key
+     * @param AbstractPublicKey $key
      * @return $this
      */
     public function setPublicKey(AbstractPublicKey $key)
@@ -349,14 +443,13 @@ final class Configuration extends AbstractEntity
 
         if (is_a($key, TestPublicKey::class)) {
             $this->testMode = true;
-        };
+        }
 
         return $this;
     }
 
     /**
-     *
-     * @param string|array $key
+     * @param AbstractSecretKey $key
      * @return $this
      */
     public function setSecretKey(AbstractSecretKey $key)
@@ -366,7 +459,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @return bool
      */
     protected function isTestMode()
@@ -375,7 +467,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @return bool
      */
     public function isHubEnabled()
@@ -388,28 +479,41 @@ final class Configuration extends AbstractEntity
         return false;
     }
 
+    /**
+     * @param GUID $hubInstallId
+     * @return void
+     */
     public function setHubInstallId(GUID $hubInstallId)
     {
         $this->hubInstallId = $hubInstallId;
     }
 
+    /**
+     * @return GUID
+     */
     public function getHubInstallId()
     {
         return $this->hubInstallId;
     }
 
+    /**
+     * @param $hubEnvironment
+     * @return void
+     */
     public function setHubEnvironment($hubEnvironment)
     {
         $this->hubEnvironment = $hubEnvironment;
     }
 
+    /**
+     * @return string
+     */
     public function getHubEnvironment()
     {
         return $this->hubEnvironment;
     }
 
     /**
-     *
      * @param bool $boletoEnabled
      * @return Configuration
      */
@@ -423,7 +527,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @param bool $creditCardEnabled
      * @return Configuration
      */
@@ -436,8 +539,7 @@ final class Configuration extends AbstractEntity
         return $this;
     }
 
-     /**
-     *
+    /**
      * @param bool $googlepayEnabled
      * @return Configuration
      */
@@ -449,6 +551,7 @@ final class Configuration extends AbstractEntity
         );
         return $this;
     }
+
     /**
      * @param $sendMailEnable
      * @return $this
@@ -476,7 +579,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @param bool $twoCreditCardsEnabled
      * @return Configuration
      */
@@ -490,7 +592,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @param bool $boletoCreditCardEnabled
      * @return Configuration
      */
@@ -504,7 +605,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @return bool
      */
     protected function isBoletoEnabled()
@@ -513,13 +613,16 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @return bool
      */
     protected function isCreditCardEnabled()
     {
         return $this->creditCardEnabled;
     }
+
+    /**
+     * @return bool
+     */
     protected function isGooglePayEnabled()
     {
         return $this->googlepayEnabled;
@@ -542,7 +645,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @return bool
      */
     protected function isTwoCreditCardsEnabled()
@@ -551,7 +653,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @return bool
      */
     protected function isBoletoCreditCardEnabled()
@@ -560,9 +661,9 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @param CardConfig $newCardConfig
      * @throws InvalidParamException
+     * @return void
      */
     public function addCardConfig(CardConfig $newCardConfig)
     {
@@ -571,7 +672,7 @@ final class Configuration extends AbstractEntity
             if ($cardConfig->equals($newCardConfig)) {
                 throw new InvalidParamException(
                     "The card config is already added!",
-                    $newCardConfig->getBrand()
+                    $newCardConfig->getBrand()->getName()
                 );
             }
         }
@@ -580,7 +681,6 @@ final class Configuration extends AbstractEntity
     }
 
     /**
-     *
      * @return CardConfig[]
      */
     protected function getCardConfigs()
@@ -638,7 +738,6 @@ final class Configuration extends AbstractEntity
 
     /**
      * @param int $antifraudMinAmount
-     * @throws InvalidParamException
      */
     public function setAntifraudMinAmount($antifraudMinAmount)
     {
@@ -802,6 +901,7 @@ final class Configuration extends AbstractEntity
 
     /**
      * @param int $boletoDueDays
+     * @throws InvalidParamException
      */
     public function setBoletoDueDays($boletoDueDays)
     {
@@ -809,7 +909,7 @@ final class Configuration extends AbstractEntity
             throw new InvalidParamException("Boleto due days should be an integer!", $boletoDueDays);
         }
 
-        $this->boletoDueDays = (int) $boletoDueDays;
+        $this->boletoDueDays = (int)$boletoDueDays;
     }
 
     /**
@@ -832,11 +932,11 @@ final class Configuration extends AbstractEntity
      * Specify data which should be serialized to JSON
      *
      * @link   https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * @return array data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
      * @since  5.4.0
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [
@@ -855,6 +955,7 @@ final class Configuration extends AbstractEntity
             "hubEnvironment" => $this->hubEnvironment,
             "merchantId" => $this->getMerchantId(),
             "accountId" => $this->getAccountId(),
+            "paymentProfileId" => $this->getPaymentProfileId(),
             "addressAttributes" => $this->getAddressAttributes(),
             "allowNoAddress" => $this->getAllowNoAddress(),
             "keys" => $this->keys,
@@ -974,11 +1075,16 @@ final class Configuration extends AbstractEntity
         return $this;
     }
 
+    /**
+     * @param $method
+     * @param $arguments
+     * @return mixed
+     */
     public function __call($method, $arguments)
     {
         $methodSplited = explode(
             "_",
-            preg_replace('/(?<=\\w)(?=[A-Z])/',"_$1", $method ?? '')
+            preg_replace('/(?<=\\w)(?=[A-Z])/', "_$1", $method ?? '')
         );
 
         $targetObject = $this;
@@ -999,6 +1105,13 @@ final class Configuration extends AbstractEntity
         return call_user_func([$targetObject, $method], $arguments);
     }
 
+    /**
+     * @param $method
+     * @param $methodSplited
+     * @param $actions
+     * @param $targetObject
+     * @return bool
+     */
     private function isMethodsIgnoringFather($method, $methodSplited, $actions, $targetObject)
     {
         $methodsIgnoringFather = ["getSecretKey", "getPublicKey", "isHubEnabled"];

--- a/tests/Kernel/Aggregates/ConfigurationTests.php
+++ b/tests/Kernel/Aggregates/ConfigurationTests.php
@@ -3,6 +3,13 @@
 namespace Pagarme\Core\Test\Kernel\Aggregates;
 
 use Pagarme\Core\Kernel\Aggregates\Configuration;
+use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
+use Pagarme\Core\Kernel\ValueObjects\CardBrand;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\CardConfig;
+use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
+use Pagarme\Core\Kernel\ValueObjects\Key\PublicKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\TestSecretKey;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTests extends TestCase
@@ -21,14 +28,14 @@ class ConfigurationTests extends TestCase
     {
         $this->configuration->setEnabled(true);
         $this->assertIsBool($this->configuration->isEnabled());
-        $this->assertEquals(true, $this->configuration->isEnabled());
+        $this->assertTrue($this->configuration->isEnabled());
     }
 
     public function testIsUnabled()
     {
         $this->configuration->setEnabled(false);
         $this->assertIsBool($this->configuration->isEnabled());
-        $this->assertEquals(false, $this->configuration->isEnabled());
+        $this->assertFalse($this->configuration->isEnabled());
     }
 
     public function testHubEnvironmentStartsNull()
@@ -49,5 +56,373 @@ class ConfigurationTests extends TestCase
         $this->configuration->setHubEnvironment('Production');
         $this->assertIsString($this->configuration->getHubEnvironment());
         $this->assertEquals('Production', $this->configuration->getHubEnvironment());
+    }
+
+    public function testDefaultValuesOnConstruction()
+    {
+        $this->assertFalse($this->configuration->isSaveCards());
+        $this->assertFalse($this->configuration->isSaveVoucherCards());
+        $this->assertFalse($this->configuration->isMultiBuyer());
+        $this->assertFalse($this->configuration->isInheritedAll());
+        $this->assertFalse($this->configuration->isInstallmentsDefaultConfig());
+        $this->assertIsArray($this->configuration->getCardConfigs());
+        $this->assertEmpty($this->configuration->getCardConfigs());
+    }
+
+    public function testBoletoEnabledSetTrue()
+    {
+        $this->configuration->setBoletoEnabled(true);
+        $this->assertIsBool($this->configuration->isBoletoEnabled());
+        $this->assertTrue($this->configuration->isBoletoEnabled());
+    }
+
+    public function testBoletoEnabledSetFalse()
+    {
+        $this->configuration->setBoletoEnabled(false);
+        $this->assertIsBool($this->configuration->isBoletoEnabled());
+        $this->assertFalse($this->configuration->isBoletoEnabled());
+    }
+
+    public function testBoletoDueDaysWithValidNumericValue()
+    {
+        $this->configuration->setBoletoDueDays(3);
+        $this->assertIsInt($this->configuration->getBoletoDueDays());
+        $this->assertEquals(3, $this->configuration->getBoletoDueDays());
+    }
+
+    public function testBoletoDueDaysWithStringNumericValue()
+    {
+        $this->configuration->setBoletoDueDays('5');
+        $this->assertIsInt($this->configuration->getBoletoDueDays());
+        $this->assertEquals(5, $this->configuration->getBoletoDueDays());
+    }
+
+    public function testBoletoDueDaysWithInvalidValueThrowsException()
+    {
+        $this->expectException(InvalidParamException::class);
+        $this->configuration->setBoletoDueDays('abc');
+    }
+
+    public function testBoletoBankCodeSetAndGet()
+    {
+        $this->configuration->setBoletoBankCode('001');
+        $this->assertIsString($this->configuration->getBoletoBankCode());
+        $this->assertEquals('001', $this->configuration->getBoletoBankCode());
+    }
+
+    public function testBoletoInstructionsSetAndGet()
+    {
+        $instructions = 'Pagar até o vencimento';
+        $this->configuration->setBoletoInstructions($instructions);
+        $this->assertEquals($instructions, $this->configuration->getBoletoInstructions());
+    }
+
+    public function testCreditCardEnabledSetTrue()
+    {
+        $this->configuration->setCreditCardEnabled(true);
+        $this->assertIsBool($this->configuration->isCreditCardEnabled());
+        $this->assertTrue($this->configuration->isCreditCardEnabled());
+    }
+
+    public function testCreditCardEnabledSetFalse()
+    {
+        $this->configuration->setCreditCardEnabled(false);
+        $this->assertFalse($this->configuration->isCreditCardEnabled());
+    }
+
+    public function testCardOperationAuthOnly()
+    {
+        $this->configuration->setCardOperation(Configuration::CARD_OPERATION_AUTH_ONLY);
+        $this->assertEquals(Configuration::CARD_OPERATION_AUTH_ONLY, $this->configuration->getCardOperation());
+        $this->assertFalse($this->configuration->isCapture());
+    }
+
+    public function testCardOperationAuthAndCapture()
+    {
+        $this->configuration->setCardOperation(Configuration::CARD_OPERATION_AUTH_AND_CAPTURE);
+        $this->assertEquals(Configuration::CARD_OPERATION_AUTH_AND_CAPTURE, $this->configuration->getCardOperation());
+        $this->assertTrue($this->configuration->isCapture());
+    }
+
+    public function testCardStatementDescriptorWithValidValue()
+    {
+        $this->configuration->setCardStatementDescriptor('Minha Loja');
+        $this->assertEquals('Minha Loja', $this->configuration->getCardStatementDescriptor());
+    }
+
+    public function testCardStatementDescriptorRemovesSpecialCharacters()
+    {
+        $this->configuration->setCardStatementDescriptor('Loja@#!');
+        $result = $this->configuration->getCardStatementDescriptor();
+        $this->assertStringNotContainsString('@', $result);
+        $this->assertStringNotContainsString('#', $result);
+        $this->assertStringNotContainsString('!', $result);
+    }
+
+    public function testCardStatementDescriptorTooLongThrowsException()
+    {
+        $this->expectException(InvalidParamException::class);
+        $this->configuration->setCardStatementDescriptor('DescricaoLongaDeMaisParaOLimite');
+    }
+
+    public function testAntifraudEnabledSetAndGet()
+    {
+        $this->configuration->setAntifraudEnabled(true);
+        $this->assertTrue($this->configuration->isAntifraudEnabled());
+    }
+
+    public function testAntifraudDisabledSetAndGet()
+    {
+        $this->configuration->setAntifraudEnabled(false);
+        $this->assertFalse($this->configuration->isAntifraudEnabled());
+    }
+
+    public function testAntifraudMinAmountStripsNonNumericCharacters()
+    {
+        $this->configuration->setAntifraudMinAmount('R$ 150,00');
+        $this->assertEquals('15000', $this->configuration->getAntifraudMinAmount());
+    }
+
+    public function testAntifraudMinAmountWithValidInteger()
+    {
+        $this->configuration->setAntifraudMinAmount(500);
+        $this->assertEquals('500', $this->configuration->getAntifraudMinAmount());
+    }
+
+    public function testAntifraudMinAmountNegativeBecomesZero()
+    {
+        $this->configuration->setAntifraudMinAmount(-100);
+        $this->assertEquals('0', $this->configuration->getAntifraudMinAmount());
+    }
+
+    public function testIsHubEnabledReturnsFalseWhenNoInstallId()
+    {
+        $this->assertFalse($this->configuration->isHubEnabled());
+    }
+
+    public function testIsHubEnabledReturnsFalseForZeroGuid()
+    {
+        $guid = new GUID('00000000-0000-0000-0000-000000000000');
+        $this->configuration->setHubInstallId($guid);
+        $this->assertFalse($this->configuration->isHubEnabled());
+    }
+
+    public function testIsHubEnabledReturnsTrueForValidGuid()
+    {
+        $guid = new GUID('12345678-1234-1234-1234-123456789012');
+        $this->configuration->setHubInstallId($guid);
+        $this->assertTrue($this->configuration->isHubEnabled());
+    }
+
+    public function testGetHubInstallIdReturnsSetGuid()
+    {
+        $guid = new GUID('12345678-1234-1234-1234-123456789012');
+        $this->configuration->setHubInstallId($guid);
+        $this->assertInstanceOf(GUID::class, $this->configuration->getHubInstallId());
+        $this->assertEquals(
+            '12345678-1234-1234-1234-123456789012',
+            $this->configuration->getHubInstallId()->getValue()
+        );
+    }
+
+    public function testGetParentIdReturnsNullWhenNoParent()
+    {
+        $this->assertNull($this->configuration->getParentId());
+    }
+
+    public function testGetMethodsInheritedReturnsEmptyArrayWhenNoParent()
+    {
+        $this->assertIsArray($this->configuration->getMethodsInherited());
+        $this->assertEmpty($this->configuration->getMethodsInherited());
+    }
+
+    public function testIsInheritedAllReturnsFalseWhenNoParent()
+    {
+        $this->assertFalse($this->configuration->isInheritedAll());
+    }
+
+    public function testIsInheritedAllReturnsFalseWithParentButFlagNotSet()
+    {
+        $parent = new Configuration();
+        $this->configuration->setParentConfiguration($parent);
+        $this->assertFalse($this->configuration->isInheritedAll());
+    }
+
+    public function testIsInheritedAllReturnsTrueWithParentAndFlagSet()
+    {
+        $parent = new Configuration();
+        $this->configuration->setParentConfiguration($parent);
+        $this->configuration->setInheritAll(true);
+        $this->assertTrue($this->configuration->isInheritedAll());
+    }
+
+    public function testGetMethodsInheritedWithParentSet()
+    {
+        $parent = new Configuration();
+        $methods = ['isBoletoEnabled', 'isCreditCardEnabled'];
+        $this->configuration->setParentConfiguration($parent);
+        $this->configuration->setMethodsInherited($methods);
+        $this->assertEquals($methods, $this->configuration->getMethodsInherited());
+    }
+
+    public function testSaveCardsDefaultIsFalse()
+    {
+        $this->assertFalse($this->configuration->isSaveCards());
+    }
+
+    public function testSaveCardsSetTrue()
+    {
+        $this->configuration->setSaveCards(true);
+        $this->assertTrue($this->configuration->isSaveCards());
+    }
+
+    public function testSaveVoucherCardsSetAndGet()
+    {
+        $this->configuration->setSaveVoucherCards(true);
+        $this->assertTrue($this->configuration->isSaveVoucherCards());
+
+        $this->configuration->setSaveVoucherCards(false);
+        $this->assertFalse($this->configuration->isSaveVoucherCards());
+    }
+
+    public function testMultiBuyerSetAndGet()
+    {
+        $this->configuration->setMultiBuyer(true);
+        $this->assertTrue($this->configuration->isMultiBuyer());
+
+        $this->configuration->setMultiBuyer(false);
+        $this->assertFalse($this->configuration->isMultiBuyer());
+    }
+
+    public function testStoreIdSetAndGet()
+    {
+        $this->configuration->setStoreId('store_123');
+        $this->assertEquals('store_123', $this->configuration->getStoreId());
+    }
+
+    public function testMerchantIdSetAndGet()
+    {
+        $this->configuration->setMerchantId('merch_123');
+        $this->assertEquals('merch_123', $this->configuration->getMerchantId());
+    }
+
+    public function testAccountIdSetAndGet()
+    {
+        $this->configuration->setAccountId('acc_123');
+        $this->assertEquals('acc_123', $this->configuration->getAccountId());
+    }
+
+    public function testAccountIdAcceptsNull()
+    {
+        $this->configuration->setAccountId(null);
+        $this->assertNull($this->configuration->getAccountId());
+    }
+
+    public function testPaymentProfileIdSetAndGet()
+    {
+        $this->configuration->setPaymentProfileId('pp_123');
+        $this->assertEquals('pp_123', $this->configuration->getPaymentProfileId());
+    }
+
+    public function testPaymentProfileIdAcceptsNull()
+    {
+        $this->configuration->setPaymentProfileId(null);
+        $this->assertNull($this->configuration->getPaymentProfileId());
+    }
+
+    public function testAddCardConfigSuccessfully()
+    {
+        $cardConfig = new CardConfig(true, CardBrand::visa(), 12, 6, 1.99, 0.50, 500);
+        $this->configuration->addCardConfig($cardConfig);
+
+        $configs = $this->configuration->getCardConfigs();
+        $this->assertCount(1, $configs);
+        $this->assertSame($cardConfig, $configs[0]);
+    }
+
+    public function testAddMultipleDistinctCardConfigs()
+    {
+        $visaConfig = new CardConfig(true, CardBrand::visa(), 12, 6, 1.99, 0.50, 500);
+        $masterConfig = new CardConfig(true, CardBrand::mastercard(), 12, 6, 1.99, 0.50, 500);
+
+        $this->configuration->addCardConfig($visaConfig);
+        $this->configuration->addCardConfig($masterConfig);
+
+        $this->assertCount(2, $this->configuration->getCardConfigs());
+        $this->assertSame([$visaConfig, $masterConfig], $this->configuration->getCardConfigs());
+    }
+
+    public function testAddDuplicateCardConfigThrowsException()
+    {
+        $this->expectException(InvalidParamException::class);
+
+        $brand           = CardBrand::visa();
+        $cardConfig      = new CardConfig(true, $brand, 12, 6, 1.99, 0.50, 500);
+        $duplicateConfig = new CardConfig(true, $brand, 12, 6, 1.99, 0.50, 500);
+
+        $this->configuration->addCardConfig($cardConfig);
+        $this->configuration->addCardConfig($duplicateConfig);
+    }
+
+    public function testDefaultTestModeIsTrue()
+    {
+        $this->assertTrue($this->configuration->isTestMode());
+    }
+
+    public function testSetTestPublicKeySetsTestModeTrue()
+    {
+        $key = new TestPublicKey('pk_test_1234567890123456');
+        $this->configuration->setPublicKey($key);
+        $this->assertTrue($this->configuration->isTestMode());
+    }
+
+    public function testSetProductionPublicKeySetsTestModeFalse()
+    {
+        $key = new PublicKey('pk_1234567890123456');
+        $this->configuration->setPublicKey($key);
+        $this->assertFalse($this->configuration->isTestMode());
+    }
+
+    public function testSetSecretKeyStoresKey()
+    {
+        $key = new TestSecretKey('sk_test_1234567890123456');
+        $this->configuration->setSecretKey($key);
+        $this->assertInstanceOf(TestSecretKey::class, $this->configuration->getSecretKey());
+    }
+
+    public function testJsonSerializeContainsAllExpectedKeys()
+    {
+        $serialized = $this->configuration->jsonSerialize();
+
+        $expectedKeys = [
+            'enabled', 'antifraudEnabled', 'antifraudMinAmount', 'boletoEnabled',
+            'creditCardEnabled', 'saveCards', 'saveVoucherCards', 'multiBuyer',
+            'twoCreditCardsEnabled', 'boletoCreditCardEnabled', 'testMode',
+            'hubInstallId', 'hubEnvironment', 'merchantId', 'accountId',
+            'paymentProfileId', 'addressAttributes', 'allowNoAddress', 'keys',
+            'cardOperation', 'installmentsEnabled', 'installmentsDefaultConfig',
+            'cardStatementDescriptor', 'boletoInstructions', 'boletoDueDays',
+            'boletoBankCode', 'cardConfigs', 'storeId', 'methodsInherited',
+            'parentId', 'parent', 'inheritAll', 'recurrenceConfig',
+            'sendMail', 'createOrder', 'voucherConfig', 'debitConfig',
+            'pixConfig', 'googlePayConfig', 'marketplaceConfig',
+        ];
+
+        foreach ($expectedKeys as $key) {
+            $this->assertArrayHasKey($key, $serialized, "Key '{$key}' is missing from jsonSerialize output.");
+        }
+    }
+
+    public function testJsonSerializeReflectsSetValues()
+    {
+        $this->configuration->setEnabled(true);
+        $this->configuration->setStoreId('store_123');
+        $this->configuration->setBoletoBankCode('001');
+
+        $serialized = $this->configuration->jsonSerialize();
+
+        $this->assertTrue($serialized['enabled']);
+        $this->assertEquals('store_123', $serialized['storeId']);
+        $this->assertEquals('001', $serialized['boletoBankCode']);
     }
 }


### PR DESCRIPTION
![David Bowie Labrynth Crystals](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGg4dWJocXlhYzFwbGNtemZsNjc3c2djcm1lNzNyZTVudzQybHVwZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EVQWoszCjUwW4/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Tarefa: [ECPJ-472](https://allstone.atlassian.net/browse/ECPJ-472)

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Adicionado o campo `paymentProfileId` à entidade `Configuration`, para suportar o modelo One Stone.

Também foi corrigido a versão do , pois o composer já não aceitava a versão anterior, impedindo que os testes unitários fossem executados.

### Cenários testados
A classe `Configuration` possuía apenas cinco testes unitários. Aumentei a cobertura criando testes para todos os cenários, não apenas os métodos que adicionei.

<img width="1255" height="261" alt="image" src="https://github.com/user-attachments/assets/dfdab283-e20f-450d-9313-be5a083ea495" />

[ECPJ-472]: https://allstone.atlassian.net/browse/ECPJ-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ