### PR TITLE
Feat: Add One Stone to ConfigurationFactory

### DIFF
--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -779,7 +779,7 @@ final class Configuration extends AbstractEntity
     /**
      * @return bool
      */
-    protected function getAllowNoAddress()
+    public function getAllowNoAddress()
     {
         return $this->allowNoAddress;
     }

--- a/src/Kernel/Factories/ConfigurationFactory.php
+++ b/src/Kernel/Factories/ConfigurationFactory.php
@@ -35,6 +35,7 @@ class ConfigurationFactory implements FactoryInterface
     public function createFromPostData($postData)
     {
         $config = new Configuration();
+        $logService = new LogService('ConfigurationFactory', true);
 
         foreach ($postData['creditCard'] as $brand => $cardConfig) {
             try {
@@ -50,14 +51,8 @@ class ConfigurationFactory implements FactoryInterface
                         null
                     )
                 );
-            } catch (Exception $e) {
-                $logService = new LogService('ConfigurationFactory', true);
-                $logService->exception($e);
             } catch (Throwable $e) {
-                $logService = new LogService('ConfigurationFactory', true);
-                $logService->info(
-                    "Unexpected error while adding CardConfig for brand '{$brand}': " . $e->getMessage()
-                );
+                $logService->exception($e);
             }
         }
 

--- a/src/Kernel/Factories/ConfigurationFactory.php
+++ b/src/Kernel/Factories/ConfigurationFactory.php
@@ -5,6 +5,7 @@ namespace Pagarme\Core\Kernel\Factories;
 use Exception;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Aggregates\Configuration;
+use Pagarme\Core\Kernel\Services\LogService;
 use Pagarme\Core\Kernel\Factories\Configurations\DebitConfigFactory;
 use Pagarme\Core\Kernel\Factories\Configurations\GooglePayConfigFactory;
 use Pagarme\Core\Kernel\Factories\Configurations\MarketplaceConfigFactory;
@@ -36,17 +37,28 @@ class ConfigurationFactory implements FactoryInterface
         $config = new Configuration();
 
         foreach ($postData['creditCard'] as $brand => $cardConfig) {
-            $config->addCardConfig(
-                new CardConfig(
-                    $cardConfig['is_enabled'],
-                    $brand,
-                    $cardConfig['installments_up_to'],
-                    $cardConfig['installments_without_interest'],
-                    $cardConfig['interest'],
-                    $cardConfig['incremental_interest'],
-                    null
-                )
-            );
+            try {
+                $brandLower = strtolower($brand);
+                $config->addCardConfig(
+                    new CardConfig(
+                        $cardConfig['is_enabled'],
+                        CardBrand::$brandLower(),
+                        $cardConfig['installments_up_to'],
+                        $cardConfig['installments_without_interest'],
+                        $cardConfig['interest'],
+                        $cardConfig['incremental_interest'],
+                        null
+                    )
+                );
+            } catch (\Exception $e) {
+                $logService = new LogService('ConfigurationFactory', true);
+                $logService->exception($e);
+            } catch (\Throwable $e) {
+                $logService = new LogService('ConfigurationFactory', true);
+                $logService->info(
+                    "Unexpected error while adding CardConfig for brand '{$brand}': " . $e->getMessage()
+                );
+            }
         }
 
         $config->setBoletoEnabled($postData['payment_pagarme_boleto_status']);

--- a/src/Kernel/Factories/ConfigurationFactory.php
+++ b/src/Kernel/Factories/ConfigurationFactory.php
@@ -50,10 +50,10 @@ class ConfigurationFactory implements FactoryInterface
                         null
                     )
                 );
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $logService = new LogService('ConfigurationFactory', true);
                 $logService->exception($e);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $logService = new LogService('ConfigurationFactory', true);
                 $logService->info(
                     "Unexpected error while adding CardConfig for brand '{$brand}': " . $e->getMessage()

--- a/src/Kernel/Factories/ConfigurationFactory.php
+++ b/src/Kernel/Factories/ConfigurationFactory.php
@@ -2,12 +2,13 @@
 
 namespace Pagarme\Core\Kernel\Factories;
 
+use Exception;
 use Pagarme\Core\Kernel\Abstractions\AbstractEntity;
 use Pagarme\Core\Kernel\Aggregates\Configuration;
 use Pagarme\Core\Kernel\Factories\Configurations\DebitConfigFactory;
+use Pagarme\Core\Kernel\Factories\Configurations\GooglePayConfigFactory;
 use Pagarme\Core\Kernel\Factories\Configurations\MarketplaceConfigFactory;
 use Pagarme\Core\Kernel\Factories\Configurations\PixConfigFactory;
-use Pagarme\Core\Kernel\Factories\Configurations\GooglePayConfigFactory;
 use Pagarme\Core\Kernel\Factories\Configurations\RecurrenceConfigFactory;
 use Pagarme\Core\Kernel\Factories\Configurations\VoucherConfigFactory;
 use Pagarme\Core\Kernel\Interfaces\FactoryInterface;
@@ -21,7 +22,7 @@ use Pagarme\Core\Kernel\ValueObjects\Key\PublicKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\SecretKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\TestSecretKey;
-use Exception;
+use Throwable;
 
 class ConfigurationFactory implements FactoryInterface
 {
@@ -94,6 +95,14 @@ class ConfigurationFactory implements FactoryInterface
 
         if (!empty($data->accountId)) {
             $config->setAccountId($data->accountId);
+        }
+
+        if (!empty($data->paymentProfileId)) {
+            $config->setPaymentProfileId($data->paymentProfileId);
+        }
+
+        if (!empty($data->poiType)) {
+            $config->setPoiType($data->poiType);
         }
 
         if (!empty($data->sendMail)) {
@@ -278,9 +287,9 @@ class ConfigurationFactory implements FactoryInterface
     {
         try {
             return new TestPublicKey($key);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
 
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
 
         }
 
@@ -291,17 +300,17 @@ class ConfigurationFactory implements FactoryInterface
     {
         try {
             return new TestSecretKey($key);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
 
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
 
         }
 
         try {
             return new SecretKey($key);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
 
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
 
         }
 
@@ -309,7 +318,6 @@ class ConfigurationFactory implements FactoryInterface
     }
 
     /**
-     *
      * @param array $dbData
      * @return AbstractEntity
      */

--- a/src/Kernel/ValueObjects/Configuration/VoucherConfig.php
+++ b/src/Kernel/ValueObjects/Configuration/VoucherConfig.php
@@ -134,7 +134,7 @@ class VoucherConfig extends AbstractValueObject
             if ($cardConfig->equals($newCardConfig)) {
                 throw new InvalidParamException(
                     "The card config is already added!",
-                    $newCardConfig->getBrand()
+                    $newCardConfig->getBrand()->getName()
                 );
             }
         }
@@ -192,12 +192,12 @@ class VoucherConfig extends AbstractValueObject
     }
 
     /**
-      * Specify data which should be serialized to JSON
-      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-      * @return mixed data which can be serialized by <b>json_encode</b>,
-      * which is a value of any type other than a resource.
-      * @since 5.4.0
-    */
+     * Specify data which should be serialized to JSON
+     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/tests/Kernel/Factories/ConfigurationFactoryTest.php
+++ b/tests/Kernel/Factories/ConfigurationFactoryTest.php
@@ -460,6 +460,45 @@ class ConfigurationFactoryTest extends TestCase
         $this->assertNull($config->getMarketplaceConfig());
     }
 
+    public function testCreateFromJsonDataSetsMerchantId()
+    {
+        $data = array_merge($this->baseData, ['merchantId' => 'merch_123']);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertEquals('merch_123', $config->getMerchantId());
+    }
+
+    public function testCreateFromJsonDataDoesNotSetMerchantIdWhenAbsent()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getMerchantId());
+    }
+
+    public function testCreateFromJsonDataSetsAccountId()
+    {
+        $data = array_merge($this->baseData, ['accountId' => 'acc_123']);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertEquals('acc_123', $config->getAccountId());
+    }
+
+    public function testCreateFromJsonDataDoesNotSetAccountIdWhenAbsent()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getAccountId());
+    }
+
+    public function testCreateFromJsonDataSetsPaymentProfileId()
+    {
+        $data = array_merge($this->baseData, ['paymentProfileId' => 'pp_123']);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertEquals('pp_123', $config->getPaymentProfileId());
+    }
+
+    public function testCreateFromJsonDataDoesNotSetPaymentProfileIdWhenAbsent()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getPaymentProfileId());
+    }
+
     public function testCreateFromJsonDataWithValidCardConfigsAddsCardConfigs()
     {
         $data = array_merge($this->baseData, [

--- a/tests/Kernel/Factories/ConfigurationFactoryTest.php
+++ b/tests/Kernel/Factories/ConfigurationFactoryTest.php
@@ -1,0 +1,621 @@
+<?php
+
+namespace Pagarme\Core\Test\Kernel\Factories;
+
+use Pagarme\Core\Kernel\Aggregates\Configuration;
+use Pagarme\Core\Kernel\Factories\ConfigurationFactory;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\AddressAttributes;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\CardConfig;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\GooglePayConfig;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\MarketplaceConfig;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\PixConfig;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\RecurrenceConfig;
+use Pagarme\Core\Kernel\ValueObjects\Configuration\VoucherConfig;
+use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
+use Pagarme\Core\Kernel\ValueObjects\Key\HubAccessTokenKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\PublicKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\SecretKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\TestSecretKey;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationFactoryTest extends TestCase
+{
+    /** @var ConfigurationFactory */
+    private $factory;
+
+    /** @var array */
+    private $baseData;
+
+    public function setUp(): void
+    {
+        $this->factory = new ConfigurationFactory();
+
+        $this->baseData = [
+            'boletoEnabled'           => true,
+            'creditCardEnabled'       => true,
+            'boletoCreditCardEnabled' => false,
+            'twoCreditCardsEnabled'   => false,
+            'hubInstallId'            => null,
+            'cardConfigs'             => [],
+        ];
+    }
+
+    public function testCreateEmptyReturnsConfigurationInstance()
+    {
+        $config = $this->factory->createEmpty();
+        $this->assertInstanceOf(Configuration::class, $config);
+    }
+
+    public function testCreateEmptyHasExpectedDefaults()
+    {
+        $config = $this->factory->createEmpty();
+        $this->assertFalse($config->isSaveCards());
+        $this->assertFalse($config->isMultiBuyer());
+        $this->assertIsArray($config->getCardConfigs());
+        $this->assertEmpty($config->getCardConfigs());
+    }
+
+    public function testCreateFromJsonDataWithTestPublicKeyCreatesTestPublicKeyInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'publicKey' => 'pk_test_xxxxxxxxxxxxxxxx',
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(TestPublicKey::class, $config->getPublicKey());
+    }
+
+    public function testCreateFromJsonDataWithProductionPublicKeyCreatesPublicKeyInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'publicKey' => 'pk_xxxxxxxxxxxxxxxx',
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(PublicKey::class, $config->getPublicKey());
+    }
+
+    public function testCreateFromJsonDataWithTestSecretKeyCreatesTestSecretKeyInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'secretKey' => 'sk_test_xxxxxxxxxxxxxxxx',
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(TestSecretKey::class, $config->getSecretKey());
+    }
+
+    public function testCreateFromJsonDataWithProductionSecretKeyCreatesSecretKeyInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'secretKey' => 'sk_xxxxxxxxxxxxxxxx',
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(SecretKey::class, $config->getSecretKey());
+    }
+
+    public function testCreateFromJsonDataWithHubAccessTokenCreatesHubAccessTokenKeyInstance()
+    {
+        $data = array_merge($this->baseData, [
+            // 64 alphanumeric characters HubAccessTokenKey standard
+            'secretKey' => str_repeat('a', 64),
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(HubAccessTokenKey::class, $config->getSecretKey());
+    }
+
+    public function testCreateFromJsonDataReadsPublicKeyFromLegacyKeysField()
+    {
+        $data = array_merge($this->baseData, [
+            'keys' => [
+                Configuration::KEY_PUBLIC => 'pk_test_xxxxxxxxxxxxxxxx',
+                Configuration::KEY_SECRET => 'sk_test_xxxxxxxxxxxxxxxx',
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(TestPublicKey::class, $config->getPublicKey());
+    }
+
+    public function testCreateFromJsonDataReadsSecretKeyFromLegacyKeysField()
+    {
+        $data = array_merge($this->baseData, [
+            'keys' => [
+                Configuration::KEY_PUBLIC => 'pk_test_xxxxxxxxxxxxxxxx',
+                Configuration::KEY_SECRET => 'sk_test_xxxxxxxxxxxxxxxx',
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(TestSecretKey::class, $config->getSecretKey());
+    }
+
+    public function testCreateFromJsonDataDoesNotOverrideExplicitPublicKeyWithLegacyKeys()
+    {
+        $data = array_merge($this->baseData, [
+            'publicKey' => 'pk_xxxxxxxxxxxxxxxx',
+            'keys'      => [
+                Configuration::KEY_PUBLIC => 'pk_test_xxxxxxxxxxxxxxxx',
+                Configuration::KEY_SECRET => 'sk_test_xxxxxxxxxxxxxxxx',
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        // Explicit public key (production) should prevail
+        $this->assertInstanceOf(PublicKey::class, $config->getPublicKey());
+    }
+
+    public function testCreateFromJsonDataSetsAntifraudDisabledByDefault()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+
+        $this->assertFalse($config->isAntifraudEnabled());
+        $this->assertEquals(0, $config->getAntifraudMinAmount());
+    }
+
+    public function testCreateFromJsonDataSetsAntifraudWhenPresent()
+    {
+        $data = array_merge($this->baseData, [
+            'antifraudEnabled'   => true,
+            'antifraudMinAmount' => 5000,
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertTrue($config->isAntifraudEnabled());
+        $this->assertEquals(5000, $config->getAntifraudMinAmount());
+    }
+
+    public function testCreateFromJsonDataSetsCreateOrderFalseByDefault()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+
+        $this->assertFalse($config->isCreateOrderEnabled());
+    }
+
+    public function testCreateFromJsonDataSetsInstallmentsEnabledFalseByDefault()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+
+        $this->assertFalse($config->isInstallmentsEnabled());
+    }
+
+    public function testCreateFromJsonDataSetsInstallmentsEnabledWhenPresent()
+    {
+        $data = array_merge($this->baseData, ['installmentsEnabled' => true]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertTrue($config->isInstallmentsEnabled());
+    }
+
+    public function testCreateFromJsonDataSetsBoletoEnabled()
+    {
+        $data = array_merge($this->baseData, ['boletoEnabled' => true]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertTrue($config->isBoletoEnabled());
+    }
+
+    public function testCreateFromJsonDataSetsBoletoDisabled()
+    {
+        $data = array_merge($this->baseData, ['boletoEnabled' => false]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertFalse($config->isBoletoEnabled());
+    }
+
+    public function testCreateFromJsonDataSetsCreditCardEnabled()
+    {
+        $data = array_merge($this->baseData, ['creditCardEnabled' => true]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertTrue($config->isCreditCardEnabled());
+    }
+
+    public function testCreateFromJsonDataSetsBoletoDueDaysAsInteger()
+    {
+        $data = array_merge($this->baseData, ['boletoDueDays' => '7']);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertIsInt($config->getBoletoDueDays());
+        $this->assertEquals(7, $config->getBoletoDueDays());
+    }
+
+    public function testCreateFromJsonDataSetsBoletoBankCode()
+    {
+        $data = array_merge($this->baseData, ['boletoBankCode' => '237']);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertEquals('237', $config->getBoletoBankCode());
+    }
+
+    public function testCreateFromJsonDataSetsBoletoInstructions()
+    {
+        $data = array_merge($this->baseData, ['boletoInstructions' => 'Pagar até o vencimento']);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertEquals('Pagar até o vencimento', $config->getBoletoInstructions());
+    }
+
+    public function testCreateFromJsonDataSetsCardStatementDescriptor()
+    {
+        $data = array_merge($this->baseData, ['cardStatementDescriptor' => 'Minha Loja']);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertEquals('Minha Loja', $config->getCardStatementDescriptor());
+    }
+
+    public function testCreateFromJsonDataSetsSaveCards()
+    {
+        $data = array_merge($this->baseData, ['saveCards' => true]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertTrue($config->isSaveCards());
+    }
+
+    public function testCreateFromJsonDataSetsSaveVoucherCards()
+    {
+        $data = array_merge($this->baseData, ['saveVoucherCards' => true]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertTrue($config->isSaveVoucherCards());
+    }
+
+    public function testCreateFromJsonDataSetsMultiBuyer()
+    {
+        $data = array_merge($this->baseData, ['multibuyer' => true]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertTrue($config->isMultiBuyer());
+    }
+
+    public function testCreateFromJsonDataSetsEnabledFlag()
+    {
+        $data = array_merge($this->baseData, ['enabled' => true]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertTrue($config->isEnabled());
+    }
+
+    public function testCreateFromJsonDataSetsCardOperation()
+    {
+        $data = array_merge($this->baseData, ['cardOperation' => Configuration::CARD_OPERATION_AUTH_ONLY]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertEquals(Configuration::CARD_OPERATION_AUTH_ONLY, $config->getCardOperation());
+    }
+
+    public function testCreateFromJsonDataSetsHubEnvironment()
+    {
+        $data = array_merge($this->baseData, ['hubEnvironment' => 'Sandbox']);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertEquals('Sandbox', $config->getHubEnvironment());
+    }
+
+    public function testCreateFromJsonDataSetsAllowNoAddress()
+    {
+        $data = array_merge($this->baseData, ['allowNoAddress' => true]);
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $this->assertTrue($config->getAllowNoAddress());
+    }
+
+    public function testCreateFromJsonDataWithNullHubInstallIdDoesNotThrow()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getHubInstallId());
+    }
+
+    public function testCreateFromJsonDataWithValidHubInstallIdCreatesGUIDInstance()
+    {
+        $guid = 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
+        $data = array_merge($this->baseData, ['hubInstallId' => $guid]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(GUID::class, $config->getHubInstallId());
+        $this->assertEquals($guid, (string) $config->getHubInstallId());
+    }
+
+    public function testCreateFromJsonDataWithAddressAttributesCreatesCorrectObject()
+    {
+        $data = array_merge($this->baseData, [
+            'addressAttributes' => [
+                'street'       => 'street',
+                'number'       => '123',
+                'neighborhood' => 'neighborhood',
+                'complement'   => 'complement',
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+        $address = $config->getAddressAttributes();
+
+        $this->assertInstanceOf(AddressAttributes::class, $address);
+        $this->assertEquals('street', $address->getStreet());
+        $this->assertEquals('123', $address->getNumber());
+        $this->assertEquals('neighborhood', $address->getNeighborhood());
+        $this->assertEquals('complement', $address->getComplement());
+    }
+
+    public function testCreateFromJsonDataWithoutAddressAttributesReturnsNull()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getAddressAttributes());
+    }
+
+    public function testCreateFromJsonDataWithPixConfigCreatesPixConfigInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'pixConfig' => [
+                'enabled'           => true,
+                'expirationQrCode'  => 300,
+                'bankType'          => 'Pagar.me',
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(PixConfig::class, $config->getPixConfig());
+        $this->assertTrue($config->getPixConfig()->isEnabled());
+        $this->assertEquals(300, $config->getPixConfig()->getExpirationQrCode());
+        $this->assertEquals('Pagar.me', $config->getPixConfig()->getBankType());
+    }
+
+    public function testCreateFromJsonDataWithoutPixConfigReturnsNull()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getPixConfig());
+    }
+
+    public function testCreateFromJsonDataWithGooglePayConfigCreatesGooglePayConfigInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'googlePayConfig' => [
+                'enabled'      => true,
+                'merchantId'   => 'merch_123',
+                'merchantName' => 'Minha Loja',
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(GooglePayConfig::class, $config->getGooglePayConfig());
+        $this->assertTrue($config->getGooglePayConfig()->isEnabled());
+        $this->assertEquals('merch_123', $config->getGooglePayConfig()->getMerchantId());
+        $this->assertEquals('Minha Loja', $config->getGooglePayConfig()->getMerchantName());
+    }
+
+    public function testCreateFromJsonDataWithoutGooglePayConfigReturnsNull()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getGooglePayConfig());
+    }
+
+    public function testCreateFromJsonDataWithRecurrenceConfigCreatesRecurrenceConfigInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'recurrenceConfig' => [
+                'enabled'      => true,
+                'decreaseStock' => true,
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(RecurrenceConfig::class, $config->getRecurrenceConfig());
+        $this->assertTrue($config->getRecurrenceConfig()->isEnabled());
+        $this->assertTrue($config->getRecurrenceConfig()->isDecreaseStock());
+    }
+
+    public function testCreateFromJsonDataWithoutRecurrenceConfigReturnsNull()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getRecurrenceConfig());
+    }
+
+    public function testCreateFromJsonDataWithVoucherConfigCreatesVoucherConfigInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'voucherConfig' => [
+                'enabled'    => true,
+                'title'      => 'Voucher',
+                'cardConfigs' => [],
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(VoucherConfig::class, $config->getVoucherConfig());
+        $this->assertTrue($config->getVoucherConfig()->isEnabled());
+        $this->assertEquals('Voucher', $config->getVoucherConfig()->getTitle());
+        $this->assertIsArray($config->getVoucherConfig()->getCardConfigs());
+        $this->assertEmpty($config->getVoucherConfig()->getCardConfigs());
+    }
+
+    public function testCreateFromJsonDataWithoutVoucherConfigReturnsNull()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getVoucherConfig());
+    }
+
+    public function testCreateFromJsonDataWithMarketplaceConfigCreatesMarketplaceConfigInstance()
+    {
+        $data = array_merge($this->baseData, [
+            'marketplaceConfig' => [
+                'enabled'        => true,
+                'mainRecipientId' => 're_xxxxxxxxxxxxxxxx',
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(MarketplaceConfig::class, $config->getMarketplaceConfig());
+        $this->assertTrue($config->getMarketplaceConfig()->isEnabled());
+        $this->assertEquals('re_xxxxxxxxxxxxxxxx', $config->getMarketplaceConfig()->getMainRecipientId());
+    }
+
+    public function testCreateFromJsonDataWithoutMarketplaceConfigReturnsNull()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+        $this->assertNull($config->getMarketplaceConfig());
+    }
+
+    public function testCreateFromJsonDataWithValidCardConfigsAddsCardConfigs()
+    {
+        $data = array_merge($this->baseData, [
+            'cardConfigs' => [
+                [
+                    'brand'                         => 'visa',
+                    'enabled'                       => true,
+                    'maxInstallment'                => 12,
+                    'maxInstallmentWithoutInterest' => 3,
+                    'initialInterest'               => 1.99,
+                    'incrementalInterest'           => 0.5,
+                    'minValue'                      => 10,
+                ],
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertCount(1, $config->getCardConfigs());
+        $this->assertInstanceOf(CardConfig::class, $config->getCardConfigs()[0]);
+    }
+
+    public function testCreateFromJsonDataWithMalformedCardConfigsDoesNotThrow()
+    {
+        $data = array_merge($this->baseData, [
+            'cardConfigs' => [
+                ['brand' => 'invalid_brand_xyz'],
+            ],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertInstanceOf(Configuration::class, $config);
+        $this->assertEmpty($config->getCardConfigs());
+    }
+
+    public function testCreateFromPostDataSetsBoletoEnabled()
+    {
+        $postData = $this->buildPostDataWithoutCreditCard(['payment_pagarme_boleto_status' => true]);
+        $config = $this->factory->createFromPostData($postData);
+        $this->assertInstanceOf(Configuration::class, $config);
+        $this->assertTrue($config->isBoletoEnabled());
+    }
+
+    public function testCreateFromPostDataSetsBoletoDisabledByDefault()
+    {
+        $postData = $this->buildPostDataWithoutCreditCard();
+        $config = $this->factory->createFromPostData($postData);
+        $this->assertFalse($config->isBoletoEnabled());
+    }
+
+    public function testCreateFromPostDataSetsCreditCardEnabled()
+    {
+        $postData = $this->buildPostDataWithoutCreditCard(['payment_pagarme_credit_card_status' => true]);
+        $config = $this->factory->createFromPostData($postData);
+        $this->assertTrue($config->isCreditCardEnabled());
+    }
+
+    public function testCreateFromPostDataSetsBoletoCreditCardEnabled()
+    {
+        $postData = $this->buildPostDataWithoutCreditCard(['payment_pagarme_boletoCreditCard_status' => true]);
+        $config = $this->factory->createFromPostData($postData);
+        $this->assertTrue($config->isBoletoCreditCardEnabled());
+    }
+
+    public function testCreateFromPostDataSetsTwoCreditCardsEnabled()
+    {
+        $postData = $this->buildPostDataWithoutCreditCard([
+            'payment_pagarme_credit_card_two_credit_cards_enabled' => true,
+        ]);
+        $config = $this->factory->createFromPostData($postData);
+        $this->assertTrue($config->isTwoCreditCardsEnabled());
+    }
+
+    public function testCreateFromPostDataSetsStoreId()
+    {
+        $postData = $this->buildPostDataWithoutCreditCard(['payment_pagarme_store_id' => 'store_42']);
+        $config = $this->factory->createFromPostData($postData);
+        $this->assertEquals('store_42', $config->getStoreId());
+    }
+
+    public function testCreateFromPostDataWithValidBrandCreatesCardConfig()
+    {
+        $postData = $this->buildPostDataWithCreditCards();
+        $config = $this->factory->createFromPostData($postData);
+
+        $this->assertInstanceOf(Configuration::class, $config);
+        $this->assertCount(1, $config->getCardConfigs());
+        $this->assertInstanceOf(CardConfig::class, $config->getCardConfigs()[0]);
+    }
+
+    public function testCreateFromPostDataWithValidBrandSetsCorrectInstallments()
+    {
+        $postData = $this->buildPostDataWithCreditCards();
+        $config = $this->factory->createFromPostData($postData);
+
+        $cardConfig = $config->getCardConfigs()[0];
+        $this->assertEquals(12, $cardConfig->getMaxInstallment());
+        $this->assertEquals(3, $cardConfig->getMaxInstallmentWithoutInterest());
+        $this->assertEquals(1.99, $cardConfig->getInitialInterest());
+        $this->assertEquals(0.5, $cardConfig->getIncrementalInterest());
+    }
+
+    public function testCreateFromPostDataWithInvalidBrandSilentlySkipsCardConfig()
+    {
+        $postData = $this->buildPostDataWithoutCreditCard([
+            'creditCard' => [
+                'InvalidBrandXyz' => [
+                    'is_enabled'                    => true,
+                    'installments_up_to'            => 6,
+                    'installments_without_interest' => 1,
+                    'interest'                      => 0.0,
+                    'incremental_interest'          => 0.0,
+                ],
+            ],
+        ]);
+
+        $config = $this->factory->createFromPostData($postData);
+
+        $this->assertInstanceOf(Configuration::class, $config);
+        $this->assertEmpty($config->getCardConfigs());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function buildPostDataWithoutCreditCard(array $overrides = []): array
+    {
+        return array_merge([
+            'payment_pagarme_boleto_status'                        => false,
+            'payment_pagarme_credit_card_status'                   => false,
+            'payment_pagarme_boletoCreditCard_status'              => false,
+            'payment_pagarme_credit_card_two_credit_cards_enabled' => false,
+            'payment_pagarme_store_id'                             => 'store_123',
+            'creditCard'                                           => [],
+        ], $overrides);
+    }
+
+    private function buildPostDataWithCreditCards(array $overrides = []): array
+    {
+        return array_merge([
+            'payment_pagarme_boleto_status'                        => false,
+            'payment_pagarme_credit_card_status'                   => false,
+            'payment_pagarme_boletoCreditCard_status'              => false,
+            'payment_pagarme_credit_card_two_credit_cards_enabled' => false,
+            'payment_pagarme_store_id'                             => 'store_123',
+            'creditCard'                                           => [
+                'Visa' => [
+                    'is_enabled'                    => true,
+                    'installments_up_to'            => 12,
+                    'installments_without_interest' => 3,
+                    'interest'                      => 1.99,
+                    'incremental_interest'          => 0.5,
+                ],
+            ],
+        ], $overrides);
+    }
+}

--- a/tests/Kernel/Factories/ConfigurationFactoryTest.php
+++ b/tests/Kernel/Factories/ConfigurationFactoryTest.php
@@ -4,6 +4,7 @@ namespace Pagarme\Core\Test\Kernel\Factories;
 
 use Pagarme\Core\Kernel\Aggregates\Configuration;
 use Pagarme\Core\Kernel\Factories\ConfigurationFactory;
+use Pagarme\Core\Kernel\ValueObjects\PoiType;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\AddressAttributes;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\CardConfig;
 use Pagarme\Core\Kernel\ValueObjects\Configuration\GooglePayConfig;
@@ -497,6 +498,81 @@ class ConfigurationFactoryTest extends TestCase
     {
         $config = $this->factory->createFromJsonData(json_encode($this->baseData));
         $this->assertNull($config->getPaymentProfileId());
+    }
+
+    public function testCreateFromJsonDataSetsPoiTypeWithValidValues()
+    {
+        $data = array_merge($this->baseData, [
+            'poiType' => [PoiType::ECOMMERCE, PoiType::LINK],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertIsArray($config->getPoiType());
+        $this->assertCount(2, $config->getPoiType());
+        $this->assertContains(PoiType::ECOMMERCE, $config->getPoiType());
+        $this->assertContains(PoiType::LINK, $config->getPoiType());
+    }
+
+    public function testCreateFromJsonDataSetsPoiTypeWithSingleValidValue()
+    {
+        $data = array_merge($this->baseData, [
+            'poiType' => [PoiType::MICRO_POS],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertIsArray($config->getPoiType());
+        $this->assertCount(1, $config->getPoiType());
+        $this->assertContains(PoiType::MICRO_POS, $config->getPoiType());
+    }
+
+    public function testCreateFromJsonDataReplacesInvalidPoiTypeWithDefault()
+    {
+        $data = array_merge($this->baseData, [
+            'poiType' => ['InvalidType'],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertIsArray($config->getPoiType());
+        $this->assertContains(PoiType::DEFAULT, $config->getPoiType());
+    }
+
+    public function testCreateFromJsonDataDoesNotSetPoiTypeWhenAbsent()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+
+        $this->assertIsArray($config->getPoiType());
+        $this->assertEmpty($config->getPoiType());
+    }
+
+    public function testCreateFromJsonDataDeduplicatesPoiTypeValues()
+    {
+        $data = array_merge($this->baseData, [
+            'poiType' => [PoiType::ECOMMERCE, PoiType::ECOMMERCE],
+        ]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertIsArray($config->getPoiType());
+        $this->assertCount(1, $config->getPoiType());
+    }
+
+    public function testCreateFromJsonDataSetsSendMailEnabled()
+    {
+        $data = array_merge($this->baseData, ['sendMail' => true]);
+
+        $config = $this->factory->createFromJsonData(json_encode($data));
+
+        $this->assertTrue($config->isSendMailEnabled());
+    }
+
+    public function testCreateFromJsonDataDoesNotSetSendMailWhenAbsent()
+    {
+        $config = $this->factory->createFromJsonData(json_encode($this->baseData));
+
+        $this->assertNull($config->isSendMailEnabled());
     }
 
     public function testCreateFromJsonDataWithValidCardConfigsAddsCardConfigs()


### PR DESCRIPTION
![David Bowie Labrynth Dance](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWRxc2lhdzNmaDVsdWlmbXRjYTI4ZXFvYWR3OXVlNWRvbWM3Yms3MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Wer0THzNFUoYE/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Tarefa: [ECPJ-474](https://allstone.atlassian.net/browse/ECPJ-474)

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Foi atualizado a `ConfigurationFactory` para processar `paymentProfileId` e `poiType` ao criar objetos de `Configuration`.

Também fiz uma correção de bug no método `createFromPostData`, onde ele adicionava uma string do nome da bandeira em `new CardConfig`, mas ele esperava um objeto `CardBrand`.

### Cenários testados
A classe `ConfigurationFactory` não possuía testes unitários. Criei testes para todos os cenários, não apenas no método que editei.

<img width="1614" height="340" alt="image" src="https://github.com/user-attachments/assets/4dc37009-d1ff-4d41-bd81-b1db405fb26e" />

Como fiz alteração no método `createFromPostData`, testei manualmente uma configuração em instalação nova e testes de compra. Tudo funcionando conforme esperado.

[ECPJ-474]: https://allstone.atlassian.net/browse/ECPJ-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ