### PR TITLE
Feat: Add One Stone to Hub InstallCommand

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         processIsolation="true"
+         processIsolation="false"
          stopOnFailure="false"
 >
     <testsuites>

--- a/src/Hub/Commands/AbstractCommand.php
+++ b/src/Hub/Commands/AbstractCommand.php
@@ -2,7 +2,6 @@
 
 namespace Pagarme\Core\Hub\Commands;
 
-
 use Pagarme\Core\Kernel\Interfaces\CommandInterface;
 use Pagarme\Core\Kernel\Services\LogService;
 use Pagarme\Core\Kernel\ValueObjects\Id\AccountId;
@@ -15,48 +14,57 @@ use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
 abstract class AbstractCommand implements CommandInterface
 {
     /**
-     *
      * @var HubAccessTokenKey
      */
     protected $accessToken;
+
     /**
-     *
      * @var AccountId
      */
     protected $accountId;
+
     /**
-     *
+     * @var string|null
+     */
+    protected $paymentProfileId;
+
+    /**
+     * @var array
+     */
+    protected $poiType;
+
+    /**
      * @var PublicKey|TestPublicKey
      */
     protected $accountPublicKey;
+
     /**
-     *
      * @var GUID
      */
     protected $installId;
+
     /**
-     *
      * @var MerchantId
      */
     protected $merchantId;
+
     /**
-     *
      * @var CommandType
      */
     protected $type;
+
     /**
-     *
      * @var LogService
      */
     protected $logService;
 
     public function __construct()
     {
+        $this->poiType = [];
         $this->logService = new LogService('Hub', true);
     }
 
     /**
-     *
      * @return HubAccessTokenKey
      */
     public function getAccessToken()
@@ -65,7 +73,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @param  HubAccessTokenKey $accessToken
      * @return AbstractCommand
      */
@@ -76,7 +83,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @return AccountId
      */
     public function getAccountId()
@@ -85,7 +91,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @param  AccountId $accountId
      * @return AbstractCommand
      */
@@ -96,7 +101,38 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
+     * @return string|null
+     */
+    public function getPaymentProfileId()
+    {
+        return $this->paymentProfileId;
+    }
+
+    /**
+     * @param string|null $paymentProfileId
+     */
+    public function setPaymentProfileId($paymentProfileId)
+    {
+        $this->paymentProfileId = $paymentProfileId;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPoiType()
+    {
+        return $this->poiType;
+    }
+
+    /**
+     * @param array $poiType
+     */
+    public function setPoiType($poiType)
+    {
+        $this->poiType = $poiType;
+    }
+
+    /**
      * @return PublicKey|TestPublicKey
      */
     public function getAccountPublicKey()
@@ -105,7 +141,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @param  PublicKey|TestPublicKey $accountPublicKey
      * @return AbstractCommand
      */
@@ -116,7 +151,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @return GUID
      */
     public function getInstallId()
@@ -125,7 +159,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @param  GUID $installId
      * @return AbstractCommand
      */
@@ -136,7 +169,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @return MerchantId
      */
     public function getMerchantId()
@@ -145,7 +177,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @param  MerchantId $merchantId
      * @return AbstractCommand
      */
@@ -156,7 +187,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @return CommandType
      */
     public function getType()
@@ -165,7 +195,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     *
      * @param  CommandType $type
      * @return AbstractCommand
      */

--- a/src/Hub/Commands/AbstractCommand.php
+++ b/src/Hub/Commands/AbstractCommand.php
@@ -110,10 +110,12 @@ abstract class AbstractCommand implements CommandInterface
 
     /**
      * @param string|null $paymentProfileId
+     * @return AbstractCommand
      */
     public function setPaymentProfileId($paymentProfileId)
     {
         $this->paymentProfileId = $paymentProfileId;
+        return $this;
     }
 
     /**
@@ -126,10 +128,12 @@ abstract class AbstractCommand implements CommandInterface
 
     /**
      * @param array $poiType
+     * @return AbstractCommand
      */
     public function setPoiType($poiType)
     {
         $this->poiType = $poiType;
+        return $this;
     }
 
     /**

--- a/src/Hub/Commands/InstallCommand.php
+++ b/src/Hub/Commands/InstallCommand.php
@@ -2,7 +2,6 @@
 
 namespace Pagarme\Core\Hub\Commands;
 
-use Exception;
 use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
 use Pagarme\Core\Kernel\Repositories\ConfigurationRepository;
 
@@ -16,17 +15,17 @@ class InstallCommand extends AbstractCommand
 
         $moduleConfig->setMerchantId($this->getMerchantId());
 
+        $moduleConfig->setPaymentProfileId($this->getPaymentProfileId());
+
+        $moduleConfig->setPoiType($this->getPoiType());
+
         $moduleConfig->setHubInstallId($this->getInstallId());
 
         $moduleConfig->setHubEnvironment($this->getType());
 
-        $moduleConfig->setPublicKey(
-            $this->getAccountPublicKey()
-        );
+        $moduleConfig->setPublicKey($this->getAccountPublicKey());
 
-        $moduleConfig->setSecretKey(
-            $this->getAccessToken()
-        );
+        $moduleConfig->setSecretKey($this->getAccessToken());
 
         $configRepo = new ConfigurationRepository();
 

--- a/src/Kernel/Abstractions/AbstractDatabaseDecorator.php
+++ b/src/Kernel/Abstractions/AbstractDatabaseDecorator.php
@@ -57,5 +57,4 @@ abstract class AbstractDatabaseDecorator
      */
     abstract protected function doFetch($query);
     abstract protected function formatResults($query);
-    abstract protected function setLastInsertId($insertId);
 }

--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -264,6 +264,24 @@ abstract class AbstractModuleCoreSetup
         }
     }
 
+    /**
+     * Resets all static state to null.
+     * Intended for use in tests only.
+     */
+    public static function reset(): void
+    {
+        static::$instance = null;
+        static::$config = null;
+        static::$moduleConfig = null;
+        static::$moduleVersion = null;
+        static::$platformVersion = null;
+        static::$logPath = null;
+        static::$platformRoot = null;
+        static::$moduleConcreteDir = null;
+        static::$dashboardLanguage = null;
+        static::$storeLanguage = null;
+    }
+
     abstract protected function setConfig();
     abstract public function loadModuleConfigurationFromPlatform();
     abstract protected function setModuleVersion();

--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -115,7 +115,7 @@ abstract class AbstractModuleCoreSetup
 
     protected static function saveModuleConfig()
     {
-        if (strpos(static::$instance->getPlatformVersion(), 'Wordpress') === false) {
+        if (strpos((string) static::$instance->getPlatformVersion(), 'Wordpress') === false) {
             $configurationRepository = new ConfigurationRepository;
             $configurationRepository->save(static::$moduleConfig);
         }
@@ -212,13 +212,13 @@ abstract class AbstractModuleCoreSetup
         return self::$platformVersion;
     }
 
-   public static function getInstallmentType() 
-   {
+    public static function getInstallmentType()
+    {
         if(method_exists(self::$instance, 'getInstallmentType')) {
             return self::$instance->getInstallmentType();
         }
         return null;
-   }
+    }
 
     public static function getLogPath()
     {

--- a/tests/Abstractions/AbstractSetupTest.php
+++ b/tests/Abstractions/AbstractSetupTest.php
@@ -2,15 +2,18 @@
 
 namespace Pagarme\Core\Test\Abstractions;
 
+use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup;
 use Pagarme\Core\Test\Mock\Concrete\Migrate;
 use Pagarme\Core\Test\Mock\Concrete\PlatformCoreSetup;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 abstract class AbstractSetupTest extends TestCase
 {
     public function setUp(): void
     {
         parent::setUp();
+        $this->resetModuleCoreSetupSingleton();
         PlatformCoreSetup::bootstrap();
     }
 
@@ -19,5 +22,22 @@ abstract class AbstractSetupTest extends TestCase
         parent::tearDown();
         $migrate = new Migrate(PlatformCoreSetup::getDatabaseAccessObject());
         $migrate->down();
+        $this->resetModuleCoreSetupSingleton();
+    }
+
+    /**
+     * Resets the AbstractModuleCoreSetup singleton so that bootstrap()
+     * re-initializes on the next setUp(), avoiding stale state after
+     * the database is torn down between tests.
+     */
+    private function resetModuleCoreSetupSingleton(): void
+    {
+        $reflection = new ReflectionClass(AbstractModuleCoreSetup::class);
+
+        foreach (['instance', 'config', 'moduleConfig', 'moduleVersion', 'platformVersion', 'logPath', 'platformRoot', 'moduleConcreteDir'] as $prop) {
+            $property = $reflection->getProperty($prop);
+            $property->setAccessible(true);
+            $property->setValue(null, null);
+        }
     }
 }

--- a/tests/Abstractions/AbstractSetupTest.php
+++ b/tests/Abstractions/AbstractSetupTest.php
@@ -2,11 +2,9 @@
 
 namespace Pagarme\Core\Test\Abstractions;
 
-use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup;
 use Pagarme\Core\Test\Mock\Concrete\Migrate;
 use Pagarme\Core\Test\Mock\Concrete\PlatformCoreSetup;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 
 abstract class AbstractSetupTest extends TestCase
 {
@@ -32,12 +30,6 @@ abstract class AbstractSetupTest extends TestCase
      */
     private function resetModuleCoreSetupSingleton(): void
     {
-        $reflection = new ReflectionClass(AbstractModuleCoreSetup::class);
-
-        foreach (['instance', 'config', 'moduleConfig', 'moduleVersion', 'platformVersion', 'logPath', 'platformRoot', 'moduleConcreteDir'] as $prop) {
-            $property = $reflection->getProperty($prop);
-            $property->setAccessible(true);
-            $property->setValue(null, null);
-        }
+        PlatformCoreSetup::reset();
     }
 }

--- a/tests/Hub/Commands/AbstractCommandTest.php
+++ b/tests/Hub/Commands/AbstractCommandTest.php
@@ -4,7 +4,6 @@ namespace Pagarme\Core\Test\Hub\Commands;
 
 use Pagarme\Core\Hub\Commands\AbstractCommand;
 use Pagarme\Core\Hub\Commands\CommandType;
-use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\ValueObjects\Id\AccountId;
 use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
 use Pagarme\Core\Kernel\ValueObjects\Id\MerchantId;
@@ -128,18 +127,14 @@ class AbstractCommandTest extends TestCase
         $this->assertEquals($type, $this->command->getType());
     }
 
-    /**
-     * @return void
-     * @throws InvalidParamException
-     */
     public function testSettersReturnSelf()
     {
-        $token   = new HubAccessTokenKey(str_repeat('x', 64));
+        $token = new HubAccessTokenKey(str_repeat('x', 64));
         $account = new AccountId('acc_xxxxxxxxxxxxxxxx');
-        $key     = new TestPublicKey('pk_test_xxxxxxxxxxxxxxxx');
-        $guid    = new GUID('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
-        $merch   = new MerchantId('merch_xxxxxxxxxxxxxxxx');
-        $type    = CommandType::Development();
+        $key = new TestPublicKey('pk_test_xxxxxxxxxxxxxxxx');
+        $guid = new GUID('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+        $merch = new MerchantId('merch_xxxxxxxxxxxxxxxx');
+        $type = CommandType::Development();
 
         $result = $this->command
             ->setAccessToken($token)

--- a/tests/Hub/Commands/AbstractCommandTest.php
+++ b/tests/Hub/Commands/AbstractCommandTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Pagarme\Core\Test\Hub\Commands;
+
+use Pagarme\Core\Hub\Commands\AbstractCommand;
+use Pagarme\Core\Hub\Commands\CommandType;
+use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
+use Pagarme\Core\Kernel\ValueObjects\Id\AccountId;
+use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
+use Pagarme\Core\Kernel\ValueObjects\Id\MerchantId;
+use Pagarme\Core\Kernel\ValueObjects\Key\HubAccessTokenKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\PublicKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
+use PHPUnit\Framework\TestCase;
+
+class AbstractCommandTest extends TestCase
+{
+    /**
+     * @var AbstractCommand
+     */
+    private $command;
+
+    public function setUp(): void
+    {
+        $this->command = $this->getMockForAbstractClass(AbstractCommand::class);
+    }
+
+    public function testPoiTypeIsEmptyArrayOnConstruction()
+    {
+        $this->assertIsArray($this->command->getPoiType());
+        $this->assertEmpty($this->command->getPoiType());
+    }
+
+    public function testSetAndGetAccessToken()
+    {
+        $token = new HubAccessTokenKey(
+            str_repeat('x', 64)
+        );
+
+        $this->command->setAccessToken($token);
+
+        $this->assertInstanceOf(HubAccessTokenKey::class, $this->command->getAccessToken());
+        $this->assertEquals($token, $this->command->getAccessToken());
+    }
+
+    public function testSetAndGetAccountId()
+    {
+        $accountId = new AccountId('acc_xxxxxxxxxxxxxxxx');
+
+        $this->command->setAccountId($accountId);
+
+        $this->assertInstanceOf(AccountId::class, $this->command->getAccountId());
+        $this->assertEquals($accountId, $this->command->getAccountId());
+    }
+
+    public function testSetAndGetPaymentProfileIdWithString()
+    {
+        $this->command->setPaymentProfileId('pp_123');
+
+        $this->assertIsString($this->command->getPaymentProfileId());
+        $this->assertEquals('pp_123', $this->command->getPaymentProfileId());
+    }
+
+    public function testSetPaymentProfileIdAcceptsNull()
+    {
+        $this->command->setPaymentProfileId(null);
+
+        $this->assertNull($this->command->getPaymentProfileId());
+    }
+
+    public function testSetAndGetPoiType()
+    {
+        $poiType = ['Ecommerce', 'ManualEntry'];
+
+        $this->command->setPoiType($poiType);
+
+        $this->assertIsArray($this->command->getPoiType());
+        $this->assertEquals($poiType, $this->command->getPoiType());
+    }
+
+    public function testSetAccountPublicKeyWithTestPublicKey()
+    {
+        $key = new TestPublicKey('pk_test_xxxxxxxxxxxxxxxx');
+
+        $this->command->setAccountPublicKey($key);
+
+        $this->assertInstanceOf(TestPublicKey::class, $this->command->getAccountPublicKey());
+        $this->assertEquals($key, $this->command->getAccountPublicKey());
+    }
+
+    public function testSetAccountPublicKeyWithPublicKey()
+    {
+        $key = new PublicKey('pk_xxxxxxxxxxxxxxxx');
+
+        $this->command->setAccountPublicKey($key);
+
+        $this->assertInstanceOf(PublicKey::class, $this->command->getAccountPublicKey());
+        $this->assertEquals($key, $this->command->getAccountPublicKey());
+    }
+
+    public function testSetAndGetInstallId()
+    {
+        $guid = new GUID('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+
+        $this->command->setInstallId($guid);
+
+        $this->assertInstanceOf(GUID::class, $this->command->getInstallId());
+        $this->assertEquals($guid, $this->command->getInstallId());
+    }
+
+    public function testSetAndGetMerchantId()
+    {
+        $merchantId = new MerchantId('merch_xxxxxxxxxxxxxxxx');
+
+        $this->command->setMerchantId($merchantId);
+
+        $this->assertInstanceOf(MerchantId::class, $this->command->getMerchantId());
+        $this->assertEquals($merchantId, $this->command->getMerchantId());
+    }
+
+    public function testSetAndGetType()
+    {
+        $type = CommandType::Sandbox();
+
+        $this->command->setType($type);
+
+        $this->assertInstanceOf(CommandType::class, $this->command->getType());
+        $this->assertEquals($type, $this->command->getType());
+    }
+
+    /**
+     * @return void
+     * @throws InvalidParamException
+     */
+    public function testSettersReturnSelf()
+    {
+        $token   = new HubAccessTokenKey(str_repeat('x', 64));
+        $account = new AccountId('acc_xxxxxxxxxxxxxxxx');
+        $key     = new TestPublicKey('pk_test_xxxxxxxxxxxxxxxx');
+        $guid    = new GUID('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+        $merch   = new MerchantId('merch_xxxxxxxxxxxxxxxx');
+        $type    = CommandType::Development();
+
+        $result = $this->command
+            ->setAccessToken($token)
+            ->setAccountId($account)
+            ->setAccountPublicKey($key)
+            ->setInstallId($guid)
+            ->setMerchantId($merch)
+            ->setType($type);
+
+        $this->assertInstanceOf(AbstractCommand::class, $result);
+    }
+}

--- a/tests/Hub/Commands/InstallCommandTest.php
+++ b/tests/Hub/Commands/InstallCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Pagarme\Core\Test\Hub\Commands;
+
+use Pagarme\Core\Hub\Commands\AbstractCommand;
+use Pagarme\Core\Hub\Commands\CommandType;
+use Pagarme\Core\Hub\Commands\InstallCommand;
+use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
+use Pagarme\Core\Kernel\ValueObjects\Id\AccountId;
+use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
+use Pagarme\Core\Kernel\ValueObjects\Id\MerchantId;
+use Pagarme\Core\Kernel\ValueObjects\Key\HubAccessTokenKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
+use Pagarme\Core\Test\Abstractions\AbstractSetupTest;
+
+class InstallCommandTest extends AbstractSetupTest
+{
+    /**
+     * @var InstallCommand
+     */
+    private $command;
+
+    private $accessToken;
+    private $accountId;
+    private $merchantId;
+    private $installId;
+    private $publicKey;
+    private $type;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->accessToken = new HubAccessTokenKey(
+            str_repeat('x', 64)
+        );
+        $this->accountId   = new AccountId('acc_xxxxxxxxxxxxxxxx');
+        $this->merchantId  = new MerchantId('merch_xxxxxxxxxxxxxxxx');
+        $this->installId   = new GUID('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+        $this->publicKey   = new TestPublicKey('pk_test_xxxxxxxxxxxxxxxx');
+        $this->type        = CommandType::Sandbox();
+
+        $this->command = new InstallCommand();
+        $this->command
+            ->setAccessToken($this->accessToken)
+            ->setAccountId($this->accountId)
+            ->setMerchantId($this->merchantId)
+            ->setInstallId($this->installId)
+            ->setAccountPublicKey($this->publicKey)
+            ->setType($this->type);
+        $this->command->setPaymentProfileId('pp_123');
+        $this->command->setPoiType(['Ecommerce']);
+    }
+
+    public function testInstallCommandIsInstanceOfAbstractCommand()
+    {
+        $this->assertInstanceOf(AbstractCommand::class, $this->command);
+    }
+
+    public function testExecuteSavesConfigurationSuccessfully()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertNotNull($config);
+    }
+
+    public function testExecutePersistsAccountId()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertInstanceOf(AccountId::class, $config->getAccountId());
+        $this->assertTrue($this->accountId->equals($config->getAccountId()));
+    }
+
+    public function testExecutePersistsMerchantId()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertInstanceOf(MerchantId::class, $config->getMerchantId());
+        $this->assertTrue($this->merchantId->equals($config->getMerchantId()));
+    }
+
+    public function testExecutePersistsPaymentProfileId()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertEquals('pp_123', $config->getPaymentProfileId());
+    }
+
+    public function testExecuteWithNullPaymentProfileId()
+    {
+        $this->command->setPaymentProfileId(null);
+
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertNull($config->getPaymentProfileId());
+    }
+
+    public function testExecutePersistsPoiType()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertIsArray($config->getPoiType());
+        $this->assertEquals(['Ecommerce'], $config->getPoiType());
+    }
+
+    public function testExecutePersistsInstallId()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertInstanceOf(GUID::class, $config->getHubInstallId());
+        $this->assertTrue($this->installId->equals($config->getHubInstallId()));
+    }
+
+    public function testExecutePersistsHubEnvironment()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertEquals($this->type, $config->getHubEnvironment());
+    }
+
+    public function testExecutePersistsTestPublicKey()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertInstanceOf(TestPublicKey::class, $config->getPublicKey());
+        $this->assertTrue($this->publicKey->equals($config->getPublicKey()));
+    }
+
+    public function testExecutePersistsSecretKey()
+    {
+        $this->command->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+        $this->assertInstanceOf(HubAccessTokenKey::class, $config->getSecretKey());
+        $this->assertTrue($this->accessToken->equals($config->getSecretKey()));
+    }
+}

--- a/tests/mock/Concrete/PlatformDatabaseDecorator.php
+++ b/tests/mock/Concrete/PlatformDatabaseDecorator.php
@@ -6,7 +6,6 @@ use Pagarme\Core\Kernel\Abstractions\AbstractDatabaseDecorator;
 
 class PlatformDatabaseDecorator extends AbstractDatabaseDecorator
 {
-
     public function getLastId()
     {
         return $this->db->lastInsertId();
@@ -70,6 +69,6 @@ class PlatformDatabaseDecorator extends AbstractDatabaseDecorator
 
     protected function setLastInsertId($insertId)
     {
-        $this->db->lastInsertId = $insertId;
+        // no-op: getLastId() reads directly from PDO::lastInsertId()
     }
 }

--- a/tests/mock/Concrete/PlatformDatabaseDecorator.php
+++ b/tests/mock/Concrete/PlatformDatabaseDecorator.php
@@ -39,7 +39,6 @@ class PlatformDatabaseDecorator extends AbstractDatabaseDecorator
     protected function doQuery($query)
     {
         $stmt = $this->db->prepare($query);
-        $this->setLastInsertId($this->db->lastInsertId());
         return $stmt->execute();
     }
 
@@ -65,10 +64,5 @@ class PlatformDatabaseDecorator extends AbstractDatabaseDecorator
         }
         $retn->rows = $queryResult;
         return $retn;
-    }
-
-    protected function setLastInsertId($insertId)
-    {
-        // no-op: getLastId() reads directly from PDO::lastInsertId()
     }
 }


### PR DESCRIPTION
![David Bowie Labyrinth Crystal Ball Waving](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExa29samgxYnZncGQ3NWlrYjFpdTgwcGx6OTd6bnBrOGU4bDZlb2FtaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/GxOIBvJa6eMo0/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Tarefa: [ECPJ-479](https://allstone.atlassian.net/browse/ECPJ-479)

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Foram atualizados `AbstractCommand` e `InstallCommand` do Hub para processar `paymentProfileId` e `poiType`.

Também foi necessário uma alteração no `phpunit.xml` para funcionamento dos testes unitários, além de correções de bugs em `AbstractModuleCoreSetup`, `AbstractDatabaseDecorator` e `PlatformDatabaseDecorator` pelo mesmo motivo.

### Cenários testados
As classes `AbstractCommand` e `InstallCommand` não possuiam testes unitários. Criei testes para todos os cenários dos mesmos:

<img width="1523" height="651" alt="image" src="https://github.com/user-attachments/assets/0a8d70e3-3f46-4435-9c2d-a4d2cc57df2c" />

Como fiz alteração nos demais arquivos mencionados acima, testei manualmente uma configuração em instalação nova e testes de compra. Tudo funcionando conforme esperado.

[ECPJ-479]: https://allstone.atlassian.net/browse/ECPJ-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ