### PR TITLE
Feat: Add One Stone to HubCommandFactory

### DIFF
--- a/src/Hub/Commands/AbstractCommand.php
+++ b/src/Hub/Commands/AbstractCommand.php
@@ -83,7 +83,7 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     * @return AccountId
+     * @return AccountId|null
      */
     public function getAccountId()
     {
@@ -91,7 +91,7 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     * @param  AccountId $accountId
+     * @param  AccountId|null $accountId
      * @return AbstractCommand
      */
     public function setAccountId($accountId)
@@ -173,7 +173,7 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     * @return MerchantId
+     * @return MerchantId|null
      */
     public function getMerchantId()
     {
@@ -181,7 +181,7 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     * @param  MerchantId $merchantId
+     * @param  MerchantId|null $merchantId
      * @return AbstractCommand
      */
     public function setMerchantId($merchantId)

--- a/src/Hub/Factories/HubCommandFactory.php
+++ b/src/Hub/Factories/HubCommandFactory.php
@@ -12,6 +12,7 @@ use Pagarme\Core\Kernel\ValueObjects\Id\MerchantId;
 use Pagarme\Core\Kernel\ValueObjects\Key\HubAccessTokenKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\PublicKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
+use Pagarme\Core\Kernel\ValueObjects\PoiType;
 use ReflectionClass;
 use ReflectionException;
 
@@ -47,7 +48,11 @@ class HubCommandFactory
             $command->setPaymentProfileId($object->paymentProfileId);
         }
 
-        $command->setPoiType($object->poiType);
+        if (!empty($object->poiType)) {
+            $command->setPoiType($object->poiType);
+        } else {
+            $command->setPoiType([]);
+        }
 
         $type = $object->type;
         $command->setType(CommandType::$type());

--- a/src/Hub/Factories/HubCommandFactory.php
+++ b/src/Hub/Factories/HubCommandFactory.php
@@ -2,8 +2,10 @@
 
 namespace Pagarme\Core\Hub\Factories;
 
+use Exception;
 use Pagarme\Core\Hub\Commands\AbstractCommand;
 use Pagarme\Core\Hub\Commands\CommandType;
+use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
 use Pagarme\Core\Kernel\ValueObjects\Id\AccountId;
 use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
 use Pagarme\Core\Kernel\ValueObjects\Id\MerchantId;
@@ -11,14 +13,15 @@ use Pagarme\Core\Kernel\ValueObjects\Key\HubAccessTokenKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\PublicKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
 use ReflectionClass;
+use ReflectionException;
 
 class HubCommandFactory
 {
     /**
-     *
      * @param  $object
      * @return AbstractCommand
-     * @throws \ReflectionException
+     * @throws ReflectionException|InvalidParamException
+     * @throws Exception
      */
     public function createFromStdClass($object)
     {
@@ -26,26 +29,28 @@ class HubCommandFactory
         $commandClass .= "\\" . $object->command . "Command";
 
         if (!class_exists($commandClass)) {
-            throw new \Exception("Invalid Command class! $commandClass");
+            throw new Exception("Invalid Command class! $commandClass");
         }
 
         /**
-         *
-        * @var AbstractCommand $command
-        */
+         * @var AbstractCommand $command
+         */
         $command = new $commandClass();
 
-        $command->setAccessToken(
-            new HubAccessTokenKey($object->access_token)
-        );
-        $command->setAccountId(
-            new AccountId($object->account_id)
-        );
+        $command->setAccessToken(new HubAccessTokenKey($object->access_token));
+
+        if (!empty($object->account_id)) {
+            $command->setAccountId(new AccountId($object->account_id));
+        }
+
+        if (!empty($object->paymentProfileId)) {
+            $command->setPaymentProfileId($object->paymentProfileId);
+        }
+
+        $command->setPoiType($object->poiType);
 
         $type = $object->type;
-        $command->setType(
-            CommandType::$type()
-        );
+        $command->setType(CommandType::$type());
 
         $publicKeyClass = PublicKey::class;
         if (
@@ -59,13 +64,11 @@ class HubCommandFactory
             new $publicKeyClass($object->account_public_key)
         );
 
-        $command->setInstallId(
-            new GUID($object->install_id)
-        );
+        $command->setInstallId(new GUID($object->install_id));
 
-        $command->setMerchantId(
-            new MerchantId($object->merchant_id)
-        );
+        if (!empty($object->merchant_id)) {
+            $command->setMerchantId(new MerchantId($object->merchant_id));
+        }
 
         return $command;
     }

--- a/src/Hub/Factories/HubCommandFactory.php
+++ b/src/Hub/Factories/HubCommandFactory.php
@@ -12,7 +12,6 @@ use Pagarme\Core\Kernel\ValueObjects\Id\MerchantId;
 use Pagarme\Core\Kernel\ValueObjects\Key\HubAccessTokenKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\PublicKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
-use Pagarme\Core\Kernel\ValueObjects\PoiType;
 use ReflectionClass;
 use ReflectionException;
 

--- a/tests/Hub/Factories/HubCommandFactoryTest.php
+++ b/tests/Hub/Factories/HubCommandFactoryTest.php
@@ -2,16 +2,28 @@
 
 namespace Pagarme\Core\Test\Hub\Factories;
 
+use Exception;
 use Pagarme\Core\Hub\Commands\AbstractCommand;
 use Pagarme\Core\Hub\Commands\CommandType;
+use Pagarme\Core\Hub\Commands\UninstallCommand;
+use Pagarme\Core\Hub\Commands\UpdateCommand;
 use Pagarme\Core\Hub\Factories\HubCommandFactory;
+use Pagarme\Core\Kernel\Exceptions\InvalidParamException;
+use Pagarme\Core\Kernel\ValueObjects\Id\AccountId;
+use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
+use Pagarme\Core\Kernel\ValueObjects\Id\MerchantId;
+use Pagarme\Core\Kernel\ValueObjects\Key\HubAccessTokenKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\PublicKey;
 use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class HubCommandFactoryTest extends TestCase
 {
+    /** @var HubCommandFactory */
     private $factory;
+
+    /** @var stdClass */
     private $payload;
 
     public function setUp(): void
@@ -24,6 +36,8 @@ class HubCommandFactoryTest extends TestCase
             "account_public_key": "pk_test_XXXXXXXXXXXXXXXX",
             "install_id": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
             "merchant_id": "merch_XXXXXXXXXXXXXXXX",
+            "paymentProfileId": "pp_XXXXXXXXXXXXXXXX",
+            "poiType": ["Ecommerce"],
             "additional_data": {},
             "type": "Development",
             "actions": [],
@@ -60,5 +74,132 @@ class HubCommandFactoryTest extends TestCase
         $hubInstall = $this->factory->createFromStdClass($this->payload);
         $this->assertEquals(CommandType::Production(), $hubInstall->getType());
         $this->assertInstanceOf(PublicKey::class, $hubInstall->getAccountPublicKey());
+    }
+
+    public function testShouldCreateHubUninstallCommand()
+    {
+        $this->payload->command = "Uninstall";
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertInstanceOf(UninstallCommand::class, $command);
+        $this->assertInstanceOf(AbstractCommand::class, $command);
+    }
+
+    public function testShouldCreateHubUpdateCommand()
+    {
+        $this->payload->command = "Update";
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertInstanceOf(UpdateCommand::class, $command);
+        $this->assertInstanceOf(AbstractCommand::class, $command);
+    }
+
+    public function testInvalidCommandShouldThrowException()
+    {
+        $this->expectException(Exception::class);
+        $this->payload->command = "NonExistent";
+        $this->factory->createFromStdClass($this->payload);
+    }
+
+    public function testFactoryPopulatesAccessToken()
+    {
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertInstanceOf(HubAccessTokenKey::class, $command->getAccessToken());
+        $this->assertEquals(
+            $this->payload->access_token,
+            $command->getAccessToken()->getValue()
+        );
+    }
+
+    public function testFactoryPopulatesAccountId()
+    {
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertInstanceOf(AccountId::class, $command->getAccountId());
+        $this->assertEquals(
+            $this->payload->account_id,
+            $command->getAccountId()->getValue()
+        );
+    }
+
+    public function testFactoryPopulatesMerchantId()
+    {
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertInstanceOf(MerchantId::class, $command->getMerchantId());
+        $this->assertEquals(
+            $this->payload->merchant_id,
+            $command->getMerchantId()->getValue()
+        );
+    }
+
+    public function testFactoryPopulatesInstallId()
+    {
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertInstanceOf(GUID::class, $command->getInstallId());
+        $this->assertEquals(
+            $this->payload->install_id,
+            $command->getInstallId()->getValue()
+        );
+    }
+
+    public function testFactoryPopulatesPaymentProfileId()
+    {
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertEquals($this->payload->paymentProfileId, $command->getPaymentProfileId());
+    }
+
+    public function testFactoryPopulatesPoiType()
+    {
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertIsArray($command->getPoiType());
+        $this->assertEquals($this->payload->poiType, $command->getPoiType());
+    }
+
+    public function testMissingAccountIdResultsInNull()
+    {
+        unset($this->payload->account_id);
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertNull($command->getAccountId());
+    }
+
+    public function testMissingMerchantIdResultsInNull()
+    {
+        unset($this->payload->merchant_id);
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertNull($command->getMerchantId());
+    }
+
+    public function testMissingPaymentProfileIdResultsInNull()
+    {
+        unset($this->payload->paymentProfileId);
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertNull($command->getPaymentProfileId());
+    }
+
+    public function testInvalidPublicKeyFormatShouldThrowInvalidParamException()
+    {
+        $this->expectException(InvalidParamException::class);
+        $this->payload->account_public_key = "pk_INVALIDO";
+        $this->factory->createFromStdClass($this->payload);
+    }
+
+    public function testProductionKeyUsedInSandboxShouldThrowInvalidParamException()
+    {
+        $this->expectException(InvalidParamException::class);
+        $this->payload->type = "Sandbox";
+        $this->payload->account_public_key = "pk_XXXXXXXXXXXXXXXX";
+        $this->factory->createFromStdClass($this->payload);
+    }
+
+    public function testTestKeyUsedInProductionShouldThrowInvalidParamException()
+    {
+        $this->expectException(InvalidParamException::class);
+        $this->payload->type = "Production";
+        $this->payload->account_public_key = "pk_test_XXXXXXXXXXXXXXXX";
+        $this->factory->createFromStdClass($this->payload);
+    }
+
+    public function testAccessTokenWithLessThan64CharsShouldThrowInvalidParamException()
+    {
+        $this->expectException(InvalidParamException::class);
+        $this->payload->access_token = "TOKEN_CURTO_INVALIDO";
+        $this->factory->createFromStdClass($this->payload);
     }
 }

--- a/tests/Hub/Factories/HubCommandFactoryTest.php
+++ b/tests/Hub/Factories/HubCommandFactoryTest.php
@@ -149,7 +149,23 @@ class HubCommandFactoryTest extends TestCase
     {
         $command = $this->factory->createFromStdClass($this->payload);
         $this->assertIsArray($command->getPoiType());
-        $this->assertEquals($this->payload->poiType, $command->getPoiType());
+        $this->assertEquals((array) $this->payload->poiType, $command->getPoiType());
+    }
+
+    public function testMissingPoiTypeResultsInEmptyArray()
+    {
+        unset($this->payload->poiType);
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertIsArray($command->getPoiType());
+        $this->assertEmpty($command->getPoiType());
+    }
+
+    public function testEmptyPoiTypeResultsInEmptyArray()
+    {
+        $this->payload->poiType = [];
+        $command = $this->factory->createFromStdClass($this->payload);
+        $this->assertIsArray($command->getPoiType());
+        $this->assertEmpty($command->getPoiType());
     }
 
     public function testMissingAccountIdResultsInNull()


### PR DESCRIPTION
![David Bowie Labyrinth Dancing with Goblings](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWM3aHFvZzU3bGVndm90cWs0NWVzc3F0dGFoaDdpMzdvaGt1OGFtdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT8qBjRI2PyQuB4T2U/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Tarefa: [ECPJ-480](https://allstone.atlassian.net/browse/ECPJ-480)

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Foi atualizado o `HubCommandFactory` para processar `paymentProfileId` e `poiType`.

### Cenários testados
A classe `HubCommandFactory` possuía apenas quatro testes unitários. Além de criar testes para o cenário de One Stone, aumentei a cobertura do restante da classe:

<img width="1547" height="333" alt="image" src="https://github.com/user-attachments/assets/171f277f-5120-4fd2-a2f7-b586db763f6a" />

[ECPJ-480]: https://allstone.atlassian.net/browse/ECPJ-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ