### PR TITLE
Feat: Add One Stone to UninstallCommand

### DIFF
--- a/src/Hub/Commands/UninstallCommand.php
+++ b/src/Hub/Commands/UninstallCommand.php
@@ -37,7 +37,7 @@ class UninstallCommand extends AbstractCommand
         $cleanConfig->accountId = null;
         $cleanConfig->merchantId = null;
         $cleanConfig->paymentProfileId = null;
-        $cleanConfig->poiType = null;
+        $cleanConfig->poiType = [];
 
         $cleanConfig = json_encode($cleanConfig);
         $configFactory = new ConfigurationFactory();

--- a/src/Hub/Commands/UninstallCommand.php
+++ b/src/Hub/Commands/UninstallCommand.php
@@ -3,7 +3,7 @@
 namespace Pagarme\Core\Hub\Commands;
 
 use Exception;
-use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as  MPSetup;
+use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
 use Pagarme\Core\Kernel\Aggregates\Configuration;
 use Pagarme\Core\Kernel\Factories\ConfigurationFactory;
 use Pagarme\Core\Kernel\Repositories\ConfigurationRepository;
@@ -22,7 +22,7 @@ class UninstallCommand extends AbstractCommand
 
         $hubKey = $moduleConfig->getSecretKey();
         if (!$hubKey->equals($this->getAccessToken())) {
-            $exception =  new Exception("Access Denied.");
+            $exception = new Exception("Access Denied.");
             $this->logService->exception($exception);
             throw $exception;
         }
@@ -34,6 +34,10 @@ class UninstallCommand extends AbstractCommand
         ];
         $cleanConfig->testMode = true;
         $cleanConfig->hubInstallId = null;
+        $cleanConfig->accountId = null;
+        $cleanConfig->merchantId = null;
+        $cleanConfig->paymentProfileId = null;
+        $cleanConfig->poiType = null;
 
         $cleanConfig = json_encode($cleanConfig);
         $configFactory = new ConfigurationFactory();
@@ -44,7 +48,6 @@ class UninstallCommand extends AbstractCommand
         $methodInherited = array_merge($method, ['getSecretKey', 'getPublicKey', 'isHubEnabled']);
 
         $cleanConfig->setMethodsInherited(array_unique($methodInherited));
-
 
         $cleanConfig->setId($moduleConfig->getId());
         MPSetup::setModuleConfiguration($cleanConfig);

--- a/tests/Hub/Commands/UninstallCommandTest.php
+++ b/tests/Hub/Commands/UninstallCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hub\Commands;
+namespace Pagarme\Core\Test\Hub\Commands;
 
 use Exception;
 use Pagarme\Core\Hub\Commands\AbstractCommand;
@@ -63,10 +63,12 @@ class UninstallCommandTest extends AbstractSetupTest
 
     public function testExecuteThrowsExceptionWhenHubIsNotInstalled()
     {
+        $cleanupCommand = new UninstallCommand();
+        $cleanupCommand->setAccessToken($this->accessToken);
+        $cleanupCommand->execute();
+
         $this->expectException(Exception::class);
         $this->expectExceptionMessage("Hub is not installed!");
-
-        parent::setUp();
 
         $command = new UninstallCommand();
         $command->setAccessToken($this->accessToken);

--- a/tests/Hub/Commands/UninstallCommandTest.php
+++ b/tests/Hub/Commands/UninstallCommandTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Hub\Commands;
+
+use Exception;
+use Pagarme\Core\Hub\Commands\AbstractCommand;
+use Pagarme\Core\Hub\Commands\CommandType;
+use Pagarme\Core\Hub\Commands\InstallCommand;
+use Pagarme\Core\Hub\Commands\UninstallCommand;
+use Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup as MPSetup;
+use Pagarme\Core\Kernel\ValueObjects\Id\AccountId;
+use Pagarme\Core\Kernel\ValueObjects\Id\GUID;
+use Pagarme\Core\Kernel\ValueObjects\Id\MerchantId;
+use Pagarme\Core\Kernel\ValueObjects\Key\HubAccessTokenKey;
+use Pagarme\Core\Kernel\ValueObjects\Key\TestPublicKey;
+use Pagarme\Core\Test\Abstractions\AbstractSetupTest;
+
+class UninstallCommandTest extends AbstractSetupTest
+{
+    /**
+     * @var UninstallCommand
+     */
+    private $uninstallCommand;
+
+    /**
+     * @var HubAccessTokenKey
+     */
+    private $accessToken;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $accessToken  = new HubAccessTokenKey(str_repeat('x', 64));
+        $accountId    = new AccountId('acc_xxxxxxxxxxxxxxxx');
+        $merchantId   = new MerchantId('merch_xxxxxxxxxxxxxxxx');
+        $installId    = new GUID('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+        $publicKey    = new TestPublicKey('pk_test_xxxxxxxxxxxxxxxx');
+        $type         = CommandType::Sandbox();
+
+        $this->accessToken = $accessToken;
+
+        $installCommand = new InstallCommand();
+        $installCommand
+            ->setAccessToken($accessToken)
+            ->setAccountId($accountId)
+            ->setMerchantId($merchantId)
+            ->setInstallId($installId)
+            ->setAccountPublicKey($publicKey)
+            ->setType($type);
+        $installCommand->setPaymentProfileId('pp_123');
+        $installCommand->setPoiType(['Ecommerce']);
+        $installCommand->execute();
+
+        $this->uninstallCommand = new UninstallCommand();
+        $this->uninstallCommand->setAccessToken($accessToken);
+    }
+
+    public function testUninstallCommandIsInstanceOfAbstractCommand()
+    {
+        $this->assertInstanceOf(AbstractCommand::class, $this->uninstallCommand);
+    }
+
+    public function testExecuteThrowsExceptionWhenHubIsNotInstalled()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Hub is not installed!");
+
+        parent::setUp();
+
+        $command = new UninstallCommand();
+        $command->setAccessToken($this->accessToken);
+        $command->execute();
+    }
+
+    public function testExecuteThrowsExceptionWhenAccessTokenDoesNotMatchSecretKey()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Access Denied.");
+
+        $wrongToken = new HubAccessTokenKey(str_repeat('y', 64));
+
+        $command = new UninstallCommand();
+        $command->setAccessToken($wrongToken);
+        $command->execute();
+    }
+
+    /**
+     * `getMethodsInherited()` returns `[]` when `parentConfiguration` is `null`
+     * (see `Configuration::getMethodsInherited`). The clean config produced by
+     * `UninstallCommand` has no parent, so the observable contract is that the
+     * inherited-method list is empty after uninstall, while the Hub-specific
+     * guard methods (`getSecretKey`, `getPublicKey`, `isHubEnabled`) are still
+     * callable directly on the object without delegation.
+     */
+    public function testExecuteInheritedMethodsListIsEmptyBecauseNoParentExists()
+    {
+        $this->uninstallCommand->execute();
+
+        $config  = MPSetup::getModuleConfiguration();
+        $methods = $config->getMethodsInherited();
+
+        $this->assertIsArray($methods);
+        $this->assertEmpty($methods);
+    }
+
+    public function testExecuteDoesNotDuplicateInheritedMethods()
+    {
+        $this->uninstallCommand->execute();
+
+        $config  = MPSetup::getModuleConfiguration();
+        $methods = $config->getMethodsInherited();
+
+        $this->assertEquals(array_unique($methods), $methods);
+    }
+
+    public function testExecutePersistsCleanConfigurationToRepository()
+    {
+        $this->uninstallCommand->execute();
+
+        $config = MPSetup::getModuleConfiguration();
+
+        $this->assertFalse($config->isHubEnabled());
+        $this->assertNull($config->getHubInstallId());
+        $this->assertNull($config->getAccountId());
+        $this->assertNull($config->getMerchantId());
+        $this->assertNull($config->getPaymentProfileId());
+        $this->assertEmpty($config->getPoiType());
+    }
+
+    public function testExecuteThrowsExceptionOnSecondCallAfterSuccessfulUninstall()
+    {
+        $this->uninstallCommand->execute();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Hub is not installed!");
+
+        $secondCommand = new UninstallCommand();
+        $secondCommand->setAccessToken($this->accessToken);
+        $secondCommand->execute();
+    }
+}


### PR DESCRIPTION
![David Bowie Labyrinth Dancing and Kicking Gobling](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZG4wNzF1dDJ4Y2h1bXY2YXYya3pmZGU4OXYzYWh2Y2xsbGthd3ozNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26BRCYMxcHxvzfCEw/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Tarefa: [ECPJ-481](https://allstone.atlassian.net/browse/ECPJ-481)

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Foi atualizado o `UninstallCommand` para processar `paymentProfileId` e `poiType`.

### Cenários testados
A classe `UninstallCommand` não possuía testes unitários. Criei testes para o cenário de One Stone, além de outros para aumentar a cobertura:

<img width="1529" height="337" alt="image" src="https://github.com/user-attachments/assets/68cc40c2-77c3-4cd4-aaf8-1cfef0c1e7e6" />

[ECPJ-481]: https://allstone.atlassian.net/browse/ECPJ-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ