### PR TITLE
fix: recursive string sanitization

### DIFF
--- a/src/Kernel/Helper/StringFunctionsHelper.php
+++ b/src/Kernel/Helper/StringFunctionsHelper.php
@@ -5,107 +5,106 @@ namespace Pagarme\Core\Kernel\Helper;
 class StringFunctionsHelper
 {
     /**
-     * @var array unwanted
+     * @var array<string, string>
      */
     private $unwanted = [
-        'À'=>'A',
-        'Á'=>'A',
-        'Â'=>'A',
-        'Ã'=>'A',
-        'Ä'=>'Ae',
-        'Å'=>'A',
-        'Æ'=>'A',
-        'Ă'=>'A',
+        'À' => 'A',
+        'Á' => 'A',
+        'Â' => 'A',
+        'Ã' => 'A',
+        'Ä' => 'Ae',
+        'Å' => 'A',
+        'Æ' => 'A',
+        'Ă' => 'A',
         'Ą' => 'A',
         'ą' => 'a',
-        'à'=>'a',
-        'á'=>'a',
-        'â'=>'a',
-        'ã'=>'a',
-        'ä'=>'ae',
-        'å'=>'a',
-        'ă'=>'a',
-        'æ'=>'ae',
-        'þ'=>'b',
-        'Þ'=>'B',
-        'Ç'=>'C',
-        'ç'=>'c',
+        'à' => 'a',
+        'á' => 'a',
+        'â' => 'a',
+        'ã' => 'a',
+        'ä' => 'ae',
+        'å' => 'a',
+        'ă' => 'a',
+        'æ' => 'ae',
+        'þ' => 'b',
+        'Þ' => 'B',
+        'Ç' => 'C',
+        'ç' => 'c',
         'Ć' => 'C',
         'ć' => 'c',
-        'È'=>'E',
-        'É'=>'E',
-        'Ê'=>'E',
-        'Ë'=>'E',
+        'È' => 'E',
+        'É' => 'E',
+        'Ê' => 'E',
+        'Ë' => 'E',
         'Ę' => 'E',
         'ę' => 'e',
-        'è'=>'e',
-        'é'=>'e',
-        'ê'=>'e',
-        'ë'=>'e',
-        'Ğ'=>'G',
-        'ğ'=>'g',
-        'Ì'=>'I',
-        'Í'=>'I',
-        'Î'=>'I',
-        'Ï'=>'I',
-        'İ'=>'I',
-        'ı'=>'i',
-        'ì'=>'i',
-        'í'=>'i',
-        'î'=>'i',
-        'ï'=>'i',
+        'è' => 'e',
+        'é' => 'e',
+        'ê' => 'e',
+        'ë' => 'e',
+        'Ğ' => 'G',
+        'ğ' => 'g',
+        'Ì' => 'I',
+        'Í' => 'I',
+        'Î' => 'I',
+        'Ï' => 'I',
+        'İ' => 'I',
+        'ı' => 'i',
+        'ì' => 'i',
+        'í' => 'i',
+        'î' => 'i',
+        'ï' => 'i',
         'Ł' => 'L',
         'ł' => 'l',
-        'Ñ'=>'N',
+        'Ñ' => 'N',
         'Ń' => 'N',
         'ń' => 'n',
-        'Ò'=>'O',
-        'Ó'=>'O',
-        'Ô'=>'O',
-        'Õ'=>'O',
-        'Ö'=>'Oe',
-        'Ø'=>'O',
-        'ö'=>'oe',
-        'ø'=>'o',
-        'ð'=>'o',
-        'ñ'=>'n',
-        'ò'=>'o',
-        'ó'=>'o',
-        'ô'=>'o',
-        'õ'=>'o',
-        'Š'=>'S',
-        'š'=>'s',
-        'Ş'=>'S',
-        'ș'=>'s',
-        'Ș'=>'S',
-        'ş'=>'s',
-        'ß'=>'ss',
+        'Ò' => 'O',
+        'Ó' => 'O',
+        'Ô' => 'O',
+        'Õ' => 'O',
+        'Ö' => 'Oe',
+        'Ø' => 'O',
+        'ö' => 'oe',
+        'ø' => 'o',
+        'ð' => 'o',
+        'ñ' => 'n',
+        'ò' => 'o',
+        'ó' => 'o',
+        'ô' => 'o',
+        'õ' => 'o',
+        'Š' => 'S',
+        'š' => 's',
+        'Ş' => 'S',
+        'ș' => 's',
+        'Ș' => 'S',
+        'ş' => 's',
+        'ß' => 'ss',
         'Ś' => 'S',
         'ś' => 's',
-        'ț'=>'t',
-        'Ț'=>'T',
-        'Ù'=>'U',
-        'Ú'=>'U',
-        'Û'=>'U',
-        'Ü'=>'Ue',
-        'ù'=>'u',
-        'ú'=>'u',
-        'û'=>'u',
-        'ü'=>'ue',
-        'Ý'=>'Y',
-        'ý'=>'y',
-        'ý'=>'y',
-        'ÿ'=>'y',
-        'Ž'=>'Z',
-        'ž'=>'z',
+        'ț' => 't',
+        'Ț' => 'T',
+        'Ù' => 'U',
+        'Ú' => 'U',
+        'Û' => 'U',
+        'Ü' => 'Ue',
+        'ù' => 'u',
+        'ú' => 'u',
+        'û' => 'u',
+        'ü' => 'ue',
+        'Ý' => 'Y',
+        'ý' => 'y',
+        'ÿ' => 'y',
+        'Ž' => 'Z',
+        'ž' => 'z',
         'Ż' => 'Z',
         'ż' => 'z',
         'Ź' => 'Z',
-        'ź' => 'z'
+        'ź' => 'z',
     ];
 
     /**
-     * @var array specialCharacters
+     * @var array<string, string>
      */
     private $specialCharacters = [
         '!' => '',
@@ -114,14 +113,13 @@ class StringFunctionsHelper
         '$' => '',
         '%' => '',
         '&' => '',
-        '*' => ''
+        '*' => '',
     ];
 
     /**
      * This method will remove all accentiation of your string
      *
      * @param string $str
-     *
      * @return string
      */
     final public function removeSpecialCharacters($str)
@@ -136,6 +134,10 @@ class StringFunctionsHelper
         );
     }
 
+    /**
+     * @param string $str
+     * @return string
+     */
     public function cleanStrToDb($str)
     {
         $str = strtr($str, $this->specialCharacters);
@@ -153,9 +155,10 @@ class StringFunctionsHelper
      */
     public static function removeLineBreaks($text)
     {
-        if($text === null) {
+        if ($text === null) {
             return "";
         }
+
         $pattern = '/\\\s+\\\s\\\r\\\n|\\\r|\\\t|\\\n\\\r|\\\n/m';
         $textCleanBreakLines = trim(
             preg_replace(
@@ -166,5 +169,90 @@ class StringFunctionsHelper
         );
 
         return str_replace(chr(9), '', $textCleanBreakLines);
+    }
+
+    /**
+     * Applies $fn recursively to every string leaf in $value.
+     *
+     * - string  → $fn is applied directly.
+     * - array   → each value is processed recursively; original keys are preserved.
+     * - object  → the object is cloned and each public property is processed recursively.
+     * - other   → returned unchanged (int, float, bool, null).
+     *
+     * @param callable $fn
+     * @param mixed    $value
+     * @return mixed
+     */
+    private function applyRecursive(callable $fn, $value)
+    {
+        if (is_string($value)) {
+            return $fn($value);
+        }
+
+        if (is_array($value)) {
+            $result = [];
+            foreach ($value as $key => $item) {
+                $result[$key] = $this->applyRecursive($fn, $item);
+            }
+            return $result;
+        }
+
+        if (is_object($value)) {
+            $clone = clone $value;
+            foreach (get_object_vars($value) as $property => $item) {
+                $clone->$property = $this->applyRecursive($fn, $item);
+            }
+            return $clone;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Applies cleanStrToDb() recursively to all string values in $value.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public function cleanRecursive($value)
+    {
+        return $this->applyRecursive(
+            function ($str) {
+                return $this->cleanStrToDb($str);
+            },
+            $value
+        );
+    }
+
+    /**
+     * Applies removeLineBreaks() recursively to all string values in $value.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public function removeLineBreaksRecursive($value)
+    {
+        return $this->applyRecursive(
+            function ($str) {
+                return self::removeLineBreaks($str);
+            },
+            $value
+        );
+    }
+
+    /**
+     * Applies removeSpecialCharacters() recursively to all string values in $value.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public function removeSpecialCharactersRecursive($value)
+    {
+        return $this->applyRecursive(
+            function ($str) {
+                return $this->removeSpecialCharacters($str);
+            },
+            $value
+        );
     }
 }

--- a/src/Kernel/Repositories/TransactionRepository.php
+++ b/src/Kernel/Repositories/TransactionRepository.php
@@ -25,20 +25,25 @@ final class TransactionRepository extends AbstractRepository
         $query .= "WHERE charge_id = '{$id}';";
 
         $result = $this->db->fetch($query);
+        $helper = new StringFunctionsHelper();
+
+        if (!empty($result['card_data'])) {
+            $result['card_data'] = json_encode(
+                $helper->removeLineBreaksRecursive(
+                    json_decode($result['card_data'], true)
+                )
+            );
+        }
+
+        if (!empty($result['transaction_data'])) {
+            $result['transaction_data'] = json_encode(
+                $helper->removeLineBreaksRecursive(
+                    json_decode($result['transaction_data'], true)
+                )
+            );
+        }
 
         $factory = new TransactionFactory();
-
-        if (!empty($result['card_data'])) {
-            $result['card_data'] = StringFunctionsHelper::removeLineBreaks(
-                $result['card_data']
-            );
-        }
-
-        if (!empty($result['card_data'])) {
-            $result['transaction_data'] = StringFunctionsHelper::removeLineBreaks(
-                $result['transaction_data']
-            );
-        }
 
         return $factory->createFromDbData($result->row);
     }
@@ -53,12 +58,20 @@ final class TransactionRepository extends AbstractRepository
         $transactionTable = $this->db->getTable(AbstractDatabaseDecorator::TABLE_TRANSACTION);
 
         $simpleObject = json_decode(json_encode($object));
+        $helper = new StringFunctionsHelper();
 
-        $cardData = json_encode($simpleObject->cardData);
-        $cardData = StringFunctionsHelper::removeLineBreaks($cardData);
+        // Sanitize all string fields on $simpleObject so that properties
+        // directly interpolated into the SQL string (acquirerMessage,
+        // acquirerName, boletoUrl, etc.) cannot break the query via
+        // unescaped single quotes or special characters.
+        $simpleObject = $helper->cleanRecursive($simpleObject);
 
-        $transactionData = (new StringFunctionsHelper)->cleanStrToDb(
-            json_encode($object->getPostData())
+        $cardData = json_encode(
+            $helper->removeLineBreaksRecursive($simpleObject->cardData)
+        );
+
+        $transactionData = json_encode(
+            $helper->cleanRecursive($object->getPostData())
         );
 
         $query = "

--- a/tests/Kernel/Helper/StringFunctionsHelperTest.php
+++ b/tests/Kernel/Helper/StringFunctionsHelperTest.php
@@ -1,0 +1,440 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pagarme\Core\Test\Kernel\Helper;
+
+use Pagarme\Core\Kernel\Helper\StringFunctionsHelper;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * @covers \Pagarme\Core\Kernel\Helper\StringFunctionsHelper
+ */
+class StringFunctionsHelperTest extends TestCase
+{
+    /** @var StringFunctionsHelper */
+    private $helper;
+
+    public function setUp(): void
+    {
+        $this->helper = new StringFunctionsHelper();
+    }
+
+    // =========================================================================
+    // removeLineBreaksRecursive
+    // =========================================================================
+
+    public function testRemoveLineBreaksRecursiveWithSimpleStringBehavesLikeOriginalMethod(): void
+    {
+        $input = "Hello\nWorld\r\nFoo\tBar";
+
+        $this->assertSame(
+            StringFunctionsHelper::removeLineBreaks($input),
+            $this->helper->removeLineBreaksRecursive($input)
+        );
+    }
+
+    public function testRemoveLineBreaksRecursiveWithNullBehavesLikeOriginalMethod(): void
+    {
+        $this->assertSame(
+            StringFunctionsHelper::removeLineBreaks(null),
+            $this->helper->removeLineBreaksRecursive(null)
+        );
+    }
+
+    public function testRemoveLineBreaksRecursiveWithFlatArrayCleansAllStringValues(): void
+    {
+        $input = [
+            'name'    => "John\nDoe",
+            'address' => "Street\r\nCity",
+            'note'    => "Tab\there",
+        ];
+
+        $result = $this->helper->removeLineBreaksRecursive($input);
+
+        $this->assertSame(['name', 'address', 'note'], array_keys($result));
+        $this->assertSame(0, substr_count($result['name'],    "\n"));
+        $this->assertSame(0, substr_count($result['address'], "\r\n"));
+        $this->assertSame(0, substr_count($result['note'],    "\t"));
+    }
+
+    public function testRemoveLineBreaksRecursiveWithNestedArrayCleansAllLevelsRecursively(): void
+    {
+        $input = [
+            'billing' => [
+                'inner' => [
+                    'deep' => "Deep\nValue\r\n",
+                ],
+                'sibling' => "Sibling\r",
+            ],
+            'top' => "Top\nLevel",
+        ];
+
+        $result = $this->helper->removeLineBreaksRecursive($input);
+
+        $this->assertSame(0, substr_count($result['billing']['inner']['deep'], "\n"));
+        $this->assertSame(0, substr_count($result['billing']['inner']['deep'], "\r\n"));
+        $this->assertSame(0, substr_count($result['billing']['sibling'],       "\r"));
+        $this->assertSame(0, substr_count($result['top'],                      "\n"));
+    }
+
+    public function testRemoveLineBreaksRecursivePreservesOriginalArrayKeys(): void
+    {
+        $input = [
+            0       => "zero\n",
+            'alpha' => "alpha\n",
+            5       => "five\n",
+        ];
+
+        $result = $this->helper->removeLineBreaksRecursive($input);
+
+        $this->assertSame([0, 'alpha', 5], array_keys($result));
+    }
+
+    public function testRemoveLineBreaksRecursiveWithStdClassReturnsSameClassType(): void
+    {
+        $nested       = new stdClass();
+        $nested->city = "Sao\r\nPaulo";
+
+        $input          = new stdClass();
+        $input->name    = "John\nDoe";
+        $input->address = $nested;
+
+        $result = $this->helper->removeLineBreaksRecursive($input);
+
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertInstanceOf(stdClass::class, $result->address);
+        $this->assertSame(0, substr_count($result->name,         "\n"));
+        $this->assertSame(0, substr_count($result->address->city, "\r\n"));
+    }
+
+    public function testRemoveLineBreaksRecursiveDoesNotMutateOriginalObject(): void
+    {
+        $input       = new stdClass();
+        $input->text = "Hello\nWorld";
+
+        $result = $this->helper->removeLineBreaksRecursive($input);
+
+        $this->assertSame("Hello\nWorld", $input->text);
+        $this->assertNotSame($input, $result);
+    }
+
+    /**
+     * @dataProvider nonStringScalarProvider
+     * @param mixed $scalar
+     */
+    public function testRemoveLineBreaksRecursivePreservesNonStringScalarsWithoutAlteringTheirType($scalar): void
+    {
+        $input = [
+            'scalar' => $scalar,
+            'str'    => "clean\nme",
+        ];
+
+        $result = $this->helper->removeLineBreaksRecursive($input);
+
+        $this->assertSame($scalar, $result['scalar']);
+        $this->assertSame(0, substr_count($result['str'], "\n"));
+    }
+
+    // =========================================================================
+    // cleanRecursive
+    // =========================================================================
+
+    public function testCleanRecursiveWithSimpleStringBehavesLikeOriginalMethod(): void
+    {
+        $input = "It's a <b>test</b> with special chars & more";
+
+        $this->assertSame(
+            $this->helper->cleanStrToDb($input),
+            $this->helper->cleanRecursive($input)
+        );
+    }
+
+    public function testCleanRecursiveWithFlatArrayCleansAllStringValues(): void
+    {
+        $input = [
+            'html'   => '<script>alert("xss")</script>',
+            'quote'  => "O'Brian",
+            'symbol' => 'Price $100 & more!',
+        ];
+
+        $result = $this->helper->cleanRecursive($input);
+
+        $this->assertSame(['html', 'quote', 'symbol'], array_keys($result));
+        $this->assertSame(0, substr_count($result['html'],   '<script>'));
+        $this->assertSame(0, substr_count($result['quote'],  "'"));
+        $this->assertSame(0, substr_count($result['symbol'], '$'));
+    }
+
+    public function testCleanRecursiveWithNestedArrayCleansAllLevelsRecursively(): void
+    {
+        $input = [
+            'billing' => [
+                'name'    => "Alice O'Malley",
+                'address' => [
+                    'street' => "<b>123 Main St</b>",
+                ],
+            ],
+        ];
+
+        $result = $this->helper->cleanRecursive($input);
+
+        $this->assertSame(0, substr_count($result['billing']['name'],              "'"));
+        $this->assertSame(0, substr_count($result['billing']['address']['street'], '<b>'));
+    }
+
+    public function testCleanRecursivePreservesOriginalArrayKeys(): void
+    {
+        $input = [
+            0        => "zero <b>tag</b>",
+            'nested' => ["inner <b>key</b>"],
+        ];
+
+        $result = $this->helper->cleanRecursive($input);
+
+        $this->assertSame([0, 'nested'], array_keys($result));
+        $this->assertSame([0], array_keys($result['nested']));
+    }
+
+    public function testCleanRecursiveWithStdClassReturnsSameClassType(): void
+    {
+        $child       = new stdClass();
+        $child->html = '<p>paragraph</p>';
+
+        $input       = new stdClass();
+        $input->name = "Bob O'Brien";
+        $input->body = $child;
+
+        $result = $this->helper->cleanRecursive($input);
+
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertInstanceOf(stdClass::class, $result->body);
+        $this->assertSame(0, substr_count($result->name,       "'"));
+        $this->assertSame(0, substr_count($result->body->html, '<p>'));
+    }
+
+    public function testCleanRecursiveDoesNotMutateOriginalObject(): void
+    {
+        $input       = new stdClass();
+        $input->name = "Bob O'Brien";
+
+        $result = $this->helper->cleanRecursive($input);
+
+        $this->assertSame("Bob O'Brien", $input->name);
+        $this->assertNotSame($input, $result);
+    }
+
+    /**
+     * @dataProvider nonStringScalarProvider
+     * @param mixed $scalar
+     */
+    public function testCleanRecursivePreservesNonStringScalarsWithoutAlteringTheirType($scalar): void
+    {
+        $input = [
+            'scalar' => $scalar,
+            'str'    => "clean <b>this</b>",
+        ];
+
+        $result = $this->helper->cleanRecursive($input);
+
+        $this->assertSame($scalar, $result['scalar']);
+        $this->assertSame(0, substr_count($result['str'], '<b>'));
+    }
+
+    // =========================================================================
+    // removeSpecialCharactersRecursive
+    // =========================================================================
+
+    public function testRemoveSpecialCharactersRecursiveWithSimpleStringBehavesLikeOriginalMethod(): void
+    {
+        $input = 'Olá Mundo! Ação & Reação';
+
+        $this->assertSame(
+            $this->helper->removeSpecialCharacters($input),
+            $this->helper->removeSpecialCharactersRecursive($input)
+        );
+    }
+
+    public function testRemoveSpecialCharactersRecursiveWithFlatArrayProducesOnlyAsciiAlphaAndSpaces(): void
+    {
+        $input = [
+            'greeting' => 'Olá!',
+            'action'   => 'Ação & Reação',
+            'name'     => 'José',
+        ];
+
+        $result = $this->helper->removeSpecialCharactersRecursive($input);
+
+        $this->assertSame(['greeting', 'action', 'name'], array_keys($result));
+
+        foreach ($result as $key => $value) {
+            $this->assertSame(
+                1,
+                preg_match('/^[a-zA-Z ]*$/', $value),
+                "Field '{$key}' still contains non-ASCII or special characters: '{$value}'"
+            );
+        }
+    }
+
+    public function testRemoveSpecialCharactersRecursiveWithNestedArrayCleansAllLevelsRecursively(): void
+    {
+        $input = [
+            'user' => [
+                'name'    => 'Ângela',
+                'hobbies' => ['Leitura!', 'Música & Arte'],
+            ],
+        ];
+
+        $result = $this->helper->removeSpecialCharactersRecursive($input);
+
+        $this->assertSame(
+            1,
+            preg_match('/^[a-zA-Z ]*$/', $result['user']['name'])
+        );
+
+        foreach ($result['user']['hobbies'] as $hobby) {
+            $this->assertSame(1, preg_match('/^[a-zA-Z ]*$/', $hobby));
+        }
+    }
+
+    public function testRemoveSpecialCharactersRecursivePreservesOriginalArrayKeys(): void
+    {
+        $input = [
+            'first' => 'Ângela!',
+            'last'  => 'Müller@',
+        ];
+
+        $result = $this->helper->removeSpecialCharactersRecursive($input);
+
+        $this->assertSame(['first', 'last'], array_keys($result));
+    }
+
+    public function testRemoveSpecialCharactersRecursiveWithStdClassReturnsSameClassType(): void
+    {
+        $nested       = new stdClass();
+        $nested->tag  = '!Héroe!';
+
+        $input        = new stdClass();
+        $input->name  = 'Ângela Ação';
+        $input->extra = $nested;
+
+        $result = $this->helper->removeSpecialCharactersRecursive($input);
+
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertInstanceOf(stdClass::class, $result->extra);
+        $this->assertSame(1, preg_match('/^[a-zA-Z ]*$/', $result->name));
+        $this->assertSame(1, preg_match('/^[a-zA-Z ]*$/', $result->extra->tag));
+    }
+
+    public function testRemoveSpecialCharactersRecursiveDoesNotMutateOriginalObject(): void
+    {
+        $input       = new stdClass();
+        $input->name = 'Ângela!';
+
+        $result = $this->helper->removeSpecialCharactersRecursive($input);
+
+        $this->assertSame('Ângela!', $input->name);
+        $this->assertNotSame($input, $result);
+    }
+
+    /**
+     * @dataProvider nonStringScalarProvider
+     * @param mixed $scalar
+     */
+    public function testRemoveSpecialCharactersRecursivePreservesNonStringScalarsWithoutAlteringTheirType($scalar): void
+    {
+        $input = [
+            'scalar' => $scalar,
+            'str'    => 'Olá!',
+        ];
+
+        $result = $this->helper->removeSpecialCharactersRecursive($input);
+
+        $this->assertSame($scalar, $result['scalar']);
+        $this->assertSame(1, preg_match('/^[a-zA-Z ]*$/', $result['str']));
+    }
+
+    // =========================================================================
+    // applyRecursive: non-string scalar passthrough (cross-method)
+    // =========================================================================
+
+    public function testIntegerPassesThroughAllThreeRecursiveMethods(): void
+    {
+        $this->assertSame(42,   $this->helper->removeLineBreaksRecursive(42));
+        $this->assertSame(42,   $this->helper->cleanRecursive(42));
+        $this->assertSame(42,   $this->helper->removeSpecialCharactersRecursive(42));
+    }
+
+    public function testFloatPassesThroughAllThreeRecursiveMethods(): void
+    {
+        $this->assertSame(3.14, $this->helper->removeLineBreaksRecursive(3.14));
+        $this->assertSame(3.14, $this->helper->cleanRecursive(3.14));
+        $this->assertSame(3.14, $this->helper->removeSpecialCharactersRecursive(3.14));
+    }
+
+    public function testBooleanTruePassesThroughAllThreeRecursiveMethods(): void
+    {
+        $this->assertSame(true, $this->helper->removeLineBreaksRecursive(true));
+        $this->assertSame(true, $this->helper->cleanRecursive(true));
+        $this->assertSame(true, $this->helper->removeSpecialCharactersRecursive(true));
+    }
+
+    public function testBooleanFalsePassesThroughAllThreeRecursiveMethods(): void
+    {
+        $this->assertSame(false, $this->helper->removeLineBreaksRecursive(false));
+        $this->assertSame(false, $this->helper->cleanRecursive(false));
+        $this->assertSame(false, $this->helper->removeSpecialCharactersRecursive(false));
+    }
+
+    public function testNullPassesThroughCleanRecursiveAndRemoveSpecialCharactersRecursive(): void
+    {
+        $this->assertSame(null, $this->helper->cleanRecursive(null));
+        $this->assertSame(null, $this->helper->removeSpecialCharactersRecursive(null));
+    }
+
+    public function testMixedTypesInDeeplyNestedArrayAreHandledCorrectly(): void
+    {
+        $input = [
+            'name'    => "John\nDoe",
+            'age'     => 30,
+            'score'   => 9.5,
+            'active'  => true,
+            'deleted' => false,
+            'notes'   => null,
+            'address' => [
+                'street' => "Main\nSt",
+                'number' => 100,
+                'extra'  => null,
+            ],
+        ];
+
+        $result = $this->helper->removeLineBreaksRecursive($input);
+
+        $this->assertSame(0,     substr_count($result['name'], "\n"));
+        $this->assertSame(30,    $result['age']);
+        $this->assertSame(9.5,   $result['score']);
+        $this->assertSame(true,  $result['active']);
+        $this->assertSame(false, $result['deleted']);
+        $this->assertSame(null,  $result['notes']);
+        $this->assertSame(0,     substr_count($result['address']['street'], "\n"));
+        $this->assertSame(100,   $result['address']['number']);
+        $this->assertSame(null,  $result['address']['extra']);
+    }
+
+    // =========================================================================
+    // Data providers
+    // =========================================================================
+
+    public function nonStringScalarProvider(): array
+    {
+        return [
+            'integer zero' => [0],
+            'integer'      => [42],
+            'float'        => [3.14],
+            'bool true'    => [true],
+            'bool false'   => [false],
+            'null'         => [null],
+        ];
+    }
+}


### PR DESCRIPTION
## Objetivo
Corrigir um bug crítico no tratamento de dados (sanitização e normalização de strings) que causa falhas de sintaxe SQL e quebra o recebimento de Webhooks no ambiente Magento 2 (MariaDB), especialmente quando payloads contêm aspas simples em campos de texto (ex: `Ze da silva Mar' All`) ou quebras de linha dentro de estruturas aninhadas.

A mudança altera o comportamento dos helpers de string para agirem de forma **recursiva em estruturas aninhadas** (arrays e objetos), garantindo a integridade dos dados antes da persistência (`json_encode`) e após a leitura (`json_decode`), além de corrigir um bug colateral de `if` duplicado na leitura do banco.

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/0ff4910f-6bd2-4dd9-9ccf-280232bf4211" />

<img width="2552" height="1080" alt="image" src="https://github.com/user-attachments/assets/f80be001-2212-4490-a6e9-b7e291703043" />

## Tarefa
* **Jira:** [HPIP-298] - [Magento 2] Bug ao receber Webhook com ' em algum campo de texto
* **Link:** https://allstone.atlassian.net/browse/HPIP-298 

## Como?
* Criação de Mecanismo Recursivo de Higienização:
  * Implementação do método privado applyRecursive na classe StringFunctionsHelper. Ele identifica dinamicamente tipos de dados (strings, arrays, objetos clonados ou escalares) para aplicar funções de transformação em profundidade, mantendo chaves originais e preservando tipos não-string (int, float, bool, null).
* Abstração de Métodos Auxiliares:
  * Adicionados os métodos públicos cleanRecursive(), removeLineBreaksRecursive() e removeSpecialCharactersRecursive(), estendendo as regras de sanitização já existentes para payloads e estruturas de dados aninhadas.
* Refatoração no Repositório de Transações:
  * Atualização da classe TransactionRepository para interceptar e limpar de forma recursiva os campos card_data, transaction_data e payloads convertidos via json_decode. Isso previne falhas de sintaxe e quebras de queries SQL provocadas por caracteres especiais não-escapados (ex: aspas simples em sobrenomes) ou quebras de linha em campos textuais complexos.
* Garantia de Qualidade (Testes Unitários):
  * Criação de uma suíte completa de testes automatizados em StringFunctionsHelperTest.php cobrindo cenários com strings simples, arrays planos, estruturas profundamente aninhadas, objetos stdClass, preservação de mutabilidade e invariabilidade de tipos não-textuais.

## Acompanhamento
### Evidências

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/385cb281-f6f9-4840-81bc-69ec13550a5c" />

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/d779d15a-957c-4165-830c-0240e74aef9f" />

* **Testes Unitários:** Foram adicionados novos testes no PHPUnit cobrindo cenários com:
  * String simples (garantia de comportamento legado).
  * Array plano e aninhado multi-nível com aspas simples e `\n`.
  * Objetos `stdClass` aninhados.
  * Preservação de tipos não-string.
* *Suíte de testes rodando localmente com 100% de sucesso (Zero Regressões).*

Exemplo de Payload que quebrava a Query antes da correção (e agora passa com sucesso):
```json
Url:
	POST: https://localhost:8443/rest/all/V1/pagarme/webhook
Headers
	X-Webhook-Asymmetric-Signature: teste-local-validacao


{
  "id": "hook_gfsdgsdf",
  "account": {
    "id": "acc_conta1",
    "name": "Uma loja
  "type": "charge.paid",
  "created_at": "2026-05-06T18:50:21.3834082Z",
  "data": {
    "amount": 41324132,
    "code": "41234132",
    "created_at": "2026-04-21T00:34:13",
    "currency": "BRL",
    "customer": {
      "address": {
        "city": "Uma cidade",
        "complement": "Uma casa",
        "country": "BR",
        "created_at": "2026-04-21T00:34:12",
        "id": "addr_ggsfdgsfd6",
        "line_1": "901,Rua Silva,Dom da silva",
        "line_2": "Apto 105A",
        "neighborhood": "Dom silva",
        "number": "901",
        "state": "RO",
        "status": "active",
        "street": "Rua Silva",
        "updated_at": "2026-04-21T00:34:12",
        "zip_code": "78015190"
      },
      "code": "412334321",
      "created_at": "2026-04-21T00:34:12",
      "delinquent": false,
      "document": "43214132",
      "email": "fadsfads@gmail.com",
      "id": "cus_fasdfasd",
      "name": "Uma pessoa",
      "phones": {
        "home_phone": {
          "area_code": "81",
          "country_code": "55",
          "number": "43214312"
        },
        "mobile_phone": {
          "area_code": "33",
          "country_code": "55",
          "number": "52345243"
        }
      },
      "type": "individual",
      "updated_at": "2026-04-21T00:34:12"
    },
    "gateway_id": "e6cbf872-6670-44c6-92d2-5ce342fd5a9b",
    "id": "ch_fadsfadsf",
    "last_transaction": {
      "acquirer_affiliation_code": "",
      "acquirer_auth_code": "4214321",
      "acquirer_message": "SUCESSO",
      "acquirer_name": "pagseguro",
      "acquirer_nsu": "41234132",
      "acquirer_return_code": "00",
      "acquirer_tid": "CHAR_693E927A-87DD-4EC7-B04B-1FFF346540A4",
      "amount": 569905,
      "antifraud_response": {
        "provider_name": "ClearSale",
        "return_message": "APA",
        "score": "31.4200",
        "status": "approved"
      },
      "card": {
        "billing_address": {
          "city": "Cuiabá",
          "complement": "Uma casa",
          "country": "BR",
          "line_1": "901,Rua Uma rua,Dom Silva",
          "line_2": "Apto 105A",
          "neighborhood": "Dom Aquino",
          "number": "901",
          "state": "MT",
          "street": "Rua Da silva",
          "zip_code": "78015190"
        },
        "brand": "Visa",
        "created_at": "2026-04-21T00:34:12",
        "exp_month": 6,
        "exp_year": 2028,
        "first_six_digits": "485464",
        "holder_document": "",
        "holder_name": "Uma pessoa Da' Silva",
        "id": "card_fadsfads",
        "last_four_digits": "4123413",
        "network_token": {
          "status": "active",
          "token_unique_reference": "52345234gvsdfgdsf"
        },
        "status": "active",
        "type": "credit",
        "updated_at": "2026-04-21T00:34:12"
      },
      "created_at": "2026-05-06T18:50:11",
      "gateway_id": "d76f2d4c-071e-4124-94c1-c66a3fbcdd8c",
      "gateway_response": {},
      "id": "tran_fadsfads",
      "installments": 12,
      "metadata": {},
      "operation_type": "capture",
      "payment_type": "PAN",
      "status": "captured",
      "success": true,
      "transaction_type": "credit_card",
      "updated_at": "2026-05-06T18:50:11"
    },
    "metadata": {
      "coreVersion": "2.8.0",
      "moduleVersion": "2.7.0",
      "platformVersion": "Magento B2B 2.4.7-p5",
      "saveOnSuccess": "false"
    },
    "order": {
      "amount": 43124132,
      "closed": true,
      "closed_at": "2026-04-21T00:34:12",
      "code": "2000721828",
      "created_at": "2026-04-21T00:34:12",
      "currency": "BRL",
      "customer_id": "cus_fadsfads",
      "id": "or_fadsfads",
      "metadata": {
        "coreVersion": "2.8.0",
        "moduleVersion": "2.7.0",
        "platformVersion": "Magento B2B 2.4.7-p5"
      },
      "status": "paid",
      "updated_at": "2026-05-06T18:50:11"
    },
    "paid_amount": 569905,
    "paid_at": "2026-04-21T00:34:13",
    "payment_method": "credit_card",
    "status": "paid",
    "updated_at": "2026-05-06T18:50:11"
  }
}

```

```json
  {
    "id": "hook_fadsfads",
    "type": "charge.paid",
    "account": {},
    "data": {
      "id": "ch_fadsfasd",
      "code": "100000001",
      "amount": 10000,
      "paid_amount": 10000,
      "status": "paid",
      "currency": "BRL",
      "payment_method": "credit_card",
      "customer": {
        "id": "cus_fadsfasd",
        "name": "João O'Brien",
        "email": "test@test.com"
      },
      "metadata": {
        "platformVersion": "Magento 2.4"
      },
      "order": {
        "id": "or_fasdfadsfasd",
        "code": "100000001",
        "metadata": {
          "coreVersion": "2.8.0",
          "moduleVersion": "2.7.0",
          "platformVersion": "Magento B2B 2.4.7-p5"
        }
      },
      "last_transaction": {
        "id": "tran_fadsfads",
        "transaction_type": "credit_card",
        "status": "captured",
        "amount": 10000,
        "paid_amount": 10000,
        "acquirer_name": "Pagarme",
        "acquirer_message": "Transação aprovada O'K — pagamento de $100 confirmado",
        "acquirer_nsu": "123456",
        "acquirer_tid": "654321",
        "acquirer_auth_code": "AUTH01",
        "installments": 1,
        "created_at": "2026-06-05T10:00:00Z",
        "card": {
          "id": "card_sadfadsfasd",
          "brand": "Visa",
          "first_six_digits": "411111", 
          "last_four_digits": "4242",
          "holder_name": "JOAO O'BRIEN",
          "exp_month": 12,
          "exp_year": 2030,
          "type": "credit"
        }
      }
    }
  }
```
### Como testar?
1. Simule a criação de uma transação enviando um webhook cujo payload de `postData` ou `cardData` possua aspas simples em campos de texto (ex: nome do portador do cartão) ou quebras de linha (`\n`) dentro de sub-arrays.
2. Verifique se o `INSERT` na tabela `pagarme_module_core_transaction` ocorre sem estourar erro de sintaxe SQL (1064).
3. Busque a transação criada e garanta que o método `findByChargeId()` consegue ler e deserializar o JSON corretamente, tratando o bug do `if` duplicado.
4. Execute a suíte de testes unitários: `composer test` ou `./vendor/bin/phpunit`.

## Guia para o Desenvolvedor
- [x] O PR altera apenas o que esta descrito na seção Objetivo
- [x] Preenchi o campo Assignee e adicionei a tag que melhor representa a alteração
- [x] Criei/Modifiquei testes de unidade
- [x] Eu revisei meu próprio código
- [x] Associei corretamente à Tarefa do Board ao Pull Request
- [x] Executei localmente os testes de unidade com sucesso
- [x] [App contém testes de integração] Executei os testes de integração com sucesso
- [x] [App contém Sonar] Nenhum novo problema adicionado no Sonar?
- [x] Se meu PR inclui ou altera alguma variável de ambiente, já criei/alterei a variável
- [x] Se existem alterações em fluxos documentados, conferi que a respectiva documentação foi atualizada
- [x] Faz sentido criar/alterar monitoramento?
- [x] Existe uma nova dependência de API ou infra que precisa ser adicionada/atualizada no healthcheck? 
## Guia para o Revisor
- [x] O PR foi preenchido corretamente
- [x] O campo Assignee foi preenchido
- [x] A tag foi preenchida (enhancement, bug, documentation, variables)
- [x] O código é fácil de ler e entender
- [x] Testei com sucesso a mudança ou vi evidências dos testes
- [x] Se o PR inclui ou altera alguma variável de ambiente, validei que a mesma já foi criada/alterada
- [x] Todos os comentários foram respondidos e existe um consenso
- [x] Se existem alterações em fluxos documentados, conferi que a respectiva documentação foi atualizada


[HPIP-298]: https://allstone.atlassian.net/browse/HPIP-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ