### PR TITLE
feat(sanitization): add URL-safe boleto sanitization

### DIFF
--- a/src/Kernel/Helper/StringFunctionsHelper.php
+++ b/src/Kernel/Helper/StringFunctionsHelper.php
@@ -150,6 +150,19 @@ class StringFunctionsHelper
     }
 
     /**
+     * URL-safe variant of cleanStrToDb: neutralizes the SQL-breaking single
+     * quote and strips tags, but preserves URL-essential chars (& ? = / : - .)
+     * that cleanStrToDb would otherwise delete.
+     *
+     * @param string|null $url
+     * @return string
+     */
+    public function cleanUrlToDb($url)
+    {
+        return str_replace("'", "`", strip_tags($url ?? ''));
+    }
+
+    /**
      * @param string $text
      * @return string
      */

--- a/src/Kernel/Repositories/TransactionRepository.php
+++ b/src/Kernel/Repositories/TransactionRepository.php
@@ -60,11 +60,13 @@ final class TransactionRepository extends AbstractRepository
         $simpleObject = json_decode(json_encode($object));
         $helper = new StringFunctionsHelper();
 
-        // Sanitize all string fields on $simpleObject so that properties
-        // directly interpolated into the SQL string (acquirerMessage,
-        // acquirerName, boletoUrl, etc.) cannot break the query via
-        // unescaped single quotes or special characters.
+        // Sanitize all string fields interpolated into the SQL string so they
+        // cannot break the query via unescaped single quotes. boletoUrl is
+        // exempted from special-char stripping so its query params (&, ?, =)
+        // survive; it still gets quote-neutralized for SQL safety.
+        $boletoUrl = $simpleObject->boletoUrl;
         $simpleObject = $helper->cleanRecursive($simpleObject);
+        $simpleObject->boletoUrl = $helper->cleanUrlToDb($boletoUrl);
 
         $cardData = json_encode(
             $helper->removeLineBreaksRecursive($simpleObject->cardData)

--- a/tests/Kernel/Helper/StringFunctionsHelperTest.php
+++ b/tests/Kernel/Helper/StringFunctionsHelperTest.php
@@ -243,6 +243,19 @@ class StringFunctionsHelperTest extends TestCase
     }
 
     // =========================================================================
+    // cleanUrlToDb
+    // =========================================================================
+
+    public function testCleanUrlToDbPreservesQueryParamsAndNeutralizesQuote(): void
+    {
+        $url = "https://boleto-payments.stone.com.br/boleto?fmt=html&id=6a6bb12d59f677cb3028a834&pk=b3bd83cbb7aac0357e66ebafe2efa64f3ff268beb315a65e52e38c5072b9cfda";
+
+        $this->assertSame($url, $this->helper->cleanUrlToDb($url));
+        $this->assertSame(0, substr_count($this->helper->cleanUrlToDb("a'b"), "'"));
+        $this->assertSame('', $this->helper->cleanUrlToDb(null));
+    }
+
+    // =========================================================================
     // removeSpecialCharactersRecursive
     // =========================================================================
 


### PR DESCRIPTION
## Objetivo

Adicionar sanitização URL-safe para URLs de boleto sem quebrar seus parâmetros de query. O problema anterior era que a função `cleanRecursive()` removia caracteres essenciais de URL (& ? = / : -) durante a sanitização SQL, invalidando links de boleto.

A solução implementa uma nova função `cleanUrlToDb()` que neutraliza apenas aspas simples (SQL injection) mas preserva caracteres válidos em URLs, permitindo que query params como `?fmt=html&id=xxx` sobrevivam à sanitização.

## Tarefa

https://allstone.atlassian.net/browse/QOS-10062

## Como?

**`StringFunctionsHelper.php`**: Novo método `cleanUrlToDb()` que:
- Substitui `'` por `` ` `` para evitar SQL injection
- Remove tags HTML com `strip_tags()`
- Preserva caracteres de URL: & ? = / : - .

**`TransactionRepository.php`**: Aplicação da nova função:
- Salva `boletoUrl` antes da sanitização recursiva
- Aplica `cleanRecursive()` a todos os campos
- Restaura `boletoUrl` com a nova função URL-safe
- Comentário atualizado explicando a razão

**`StringFunctionsHelperTest.php`**: Testes unitários cobrindo:
- Preservação de query params em URL de boleto real
- Neutralização de aspas simples
- Tratamento de null

## Acompanhamento

### Evidências

<img width="1795" height="1253" alt="image" src="https://github.com/user-attachments/assets/31e7efea-e51b-4288-bd8c-b994e9435f81" />

<img width="2015" height="1256" alt="image" src="https://github.com/user-attachments/assets/4cb04d35-2e10-4b16-b7b6-e0490bce0822" />

<img width="2013" height="1251" alt="2026-07-30_19-14" src="https://github.com/user-attachments/assets/848b714a-c153-475c-b4d5-b8d54690e233" />

Testes unitários passam para o novo método com:
- URL de boleto real com query params: `https://boleto-payments.stone.com.br/boleto?fmt=html&id=...`
- Teste de neutralização de quote: `a'b` → sem aspas simples
- Teste de null: `null` → string vazia

### Como testar?

1. Execute os testes unitários:
   ```bash
   ./vendor/bin/phpunit tests/Kernel/Helper/StringFunctionsHelperTest.php::testCleanUrlToDbPreservesQueryParamsAndNeutralizesQuote
   ```

2. Verifique localmente que boleto URLs com query params funcionam:
   - Crie uma transação com `boletoUrl` contendo `?` e `&`
   - Confirme que a URL é armazenada intacta no banco

3. Valide SQL injection protection:
   - Teste com `boletoUrl` contendo `'` (quote)
   - Confirme que a query executa sem erro

## Guia para o Desenvolvedor
- [x] O PR altera apenas o que está descrito na seção Objetivo
- [x] Preenchi o campo Assignee e adicionei a tag que melhor representa a alteração
- [x] Criei/Modifiquei testes de unidade
- [x] Eu revisei meu próprio código
- [x] Associei corretamente à Tarefa do Board ao Pull Request
- [x] Executei localmente os testes de unidade com sucesso
- [x] [App contém testes de integração] Executei os testes de integração com sucesso
- [x] [App contém Sonar] Nenhum novo problema adicionado no Sonar?
- [x] Se meu PR inclui ou altera alguma variável de ambiente, já criei/alterei a variável
- [x] Se existem alterações em fluxos documentados, conferi que a respectiva documentação foi atualizada
- [x] Faz sentido criar/alterar monitoramento?
- [x] Existe uma nova dependência de API ou infra que precisa ser adicionada/atualizada no healthcheck?

## Guia para o Revisor
- [ ] O PR foi preenchido corretamente
- [ ] O campo Assignee foi preenchido
- [ ] A tag foi preenchida (enhancement, bug, documentation, variables)
- [ ] O código é fácil de ler e entender
- [ ] Testei com sucesso a mudança ou vi evidências dos testes
- [ ] Se o PR inclui ou altera alguma variável de ambiente, validei que a mesma já foi criada/alterada
- [ ] Todos os comentários foram respondidos e existe um consenso
- [ ] Se existem alterações em fluxos documentados, conferi que a respectiva documentação foi atualizada